### PR TITLE
Setup code coverage reporting and logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ _ide_helper_models.php
 /storage/medialibrary/temp
 /storage/media-library/temp
 .php_cs.cache
+.phpunit.result.cache
+/build/

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,19 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         verbose="true"
+>
   <coverage processUncoveredFiles="true">
     <include>
       <directory suffix=".php">./app</directory>
     </include>
+    <report>
+      <html outputDirectory="build/coverage"/>
+      <text outputFile="build/coverage.txt"/>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
   </coverage>
+  <logging>
+    <junit outputFile="build/report.junit.xml"/>
+  </logging>
   <testsuites>
     <testsuite name="Default">
-      <directory suffix="Test.php">./tests/</directory>
+      <directory>./tests/</directory>
     </testsuite>
     <testsuite name="Unit">
-      <directory suffix="Test.php">./tests/Unit</directory>
+      <directory>./tests/Unit</directory>
     </testsuite>
     <testsuite name="Feature">
-      <directory suffix="Test.php">./tests/Feature</directory>
+      <directory>./tests/Feature</directory>
     </testsuite>
   </testsuites>
   <php>


### PR DESCRIPTION
Added code coverage reporting and logging based on your `package-skeleton-laravel`, but with removed redundant attributes like `suffix="Test.php"`.