### PR TITLE
Replace non-allowed HTML elements inside of h-tags

### DIFF
--- a/resources/views/front/pages/home/partials/news.blade.php
+++ b/resources/views/front/pages/home/partials/news.blade.php
@@ -1,24 +1,24 @@
 <section id="news">
     <div class="wrap wrap-6 gapy-0 items-end">
         <div class="sm:col-span-3 | line-l">
-                <h2 class="title-sm">
-                        Latest insights
-                        <div class="title-subtext text-pink-dark">
-                            From the team
-                        </div>
-                    </h2>
+            <h2 class="title-sm">
+                Latest insights
+                <span class="title-subtext text-pink-dark block">
+                    From the team
+                </span>
+            </h2>
 
-                @foreach ($insights->slice(0, 2) as $insight)
-                    <p class="mt-4">
-                       <a class="link link-black" href="{{ $insight->url }}" target="_blank" rel="noreferrer noopener">{{ $insight->title }}</a>
-                       <br>
-                       <span class="text-xs text-gray">
-                           {{ $insight->created_at->format('M jS Y') }}
-                           <span class="char-separator" >•</span>
-                           <a class="link-underline link-blue" href="{{ $insight->url }}" target="_blank" rel="noreferrer noopener">{{ $insight->website }}</a>
-                       </span>
-                   </p>
-               @endforeach
+            @foreach ($insights->slice(0, 2) as $insight)
+                <p class="mt-4">
+                   <a class="link link-black" href="{{ $insight->url }}" target="_blank" rel="noreferrer noopener">{{ $insight->title }}</a>
+                   <br>
+                   <span class="text-xs text-gray">
+                       {{ $insight->created_at->format('M jS Y') }}
+                       <span class="char-separator" >•</span>
+                       <a class="link-underline link-blue" href="{{ $insight->url }}" target="_blank" rel="noreferrer noopener">{{ $insight->website }}</a>
+                   </span>
+               </p>
+           @endforeach
         </div>
         <div class="sm:col-span-3 | line-l">
             @foreach ($insights->slice(2, 2) as $insight)

--- a/resources/views/front/pages/home/partials/portfolio.blade.php
+++ b/resources/views/front/pages/home/partials/portfolio.blade.php
@@ -9,9 +9,9 @@
             <div class="markup links-blue links-underline | sm:grid-text-right">
                 <h3 class="title">
                     Front Line PHP
-                    <div class="title-subtext text-pink-dark">
+                    <span class="title-subtext text-pink-dark block">
                         Book<span class="font-normal"> + </span>free videos <span class="font-normal">on PHP 8</span>
-                    </div>
+                    </span>
                 </h3>
                 <p class="text-lg font-semibold">
                     Launching in december 2020! </p>
@@ -20,7 +20,7 @@
                 </p>
                 <ul class="text-lg mt-8">
                     <li class="flex items-baseline">
-                        <span class="icon fill-current text-pink-dark">{{ svg('icons/far-angle-right') }}</span> 
+                        <span class="icon fill-current text-pink-dark">{{ svg('icons/far-angle-right') }}</span>
                         <span class="ml-1">Subscribe at <a href="https://front-line-php.com" target="_blank" rel="nofollow noreferrer noopener">front-line-php.com</a> to get previews and early access.</span>
                     </li>
                 </ul>
@@ -38,9 +38,9 @@
             <div class="markup links-blue links-underline">
                 <h3 class="title">
                     Laravel Beyond CRUD
-                    <div class="title-subtext text-pink-dark">
-                        <span class="font-normal">Book + Premium Video Course
-                    </div>
+                    <span class="title-subtext text-pink-dark block">
+                        Book<span class="font-normal"> + </span>Premium Video Course
+                    </span>
                 </h3>
                 <p class="text-lg">
                     Learn how to build larger-than-average Laravel applications in our new book and video course. The knowledge in this course is built from the years of experience our team has building large, robust applications.
@@ -63,10 +63,10 @@
             <div class="markup links-blue links-underline | sm:grid-text-right">
                 <h3 class="title">
                     Ignition + Flare
-                    <div class="title-subtext text-pink-dark">
+                    <span class="title-subtext text-pink-dark block">
                         Error page<span class="font-normal"> + </span>tracker <span class="font-normal">for
                             Laravel</span>
-                    </div>
+                    </span>
                 </h3>
                 <p class="text-lg">
                     Ignition is a free and shareable error page that ships with Laravel 6 and up. It's built to keep you
@@ -91,9 +91,9 @@
             <div class="markup links-blue links-underline">
                 <h3 class="title">
                     Newsletter software and package
-                    <div class="title-subtext text-pink-dark">
+                    <span class="title-subtext text-pink-dark block">
                         <span class="font-normal">Including</span> video course
-                    </div>
+                    </span>
                 </h3>
                 <p class="text-lg">
                     Mailcoach is a self-hosted dashboard to setup mailing lists, send out newsletter campaigns and track the success.
@@ -116,9 +116,9 @@
             <div class="markup links-blue links-underline | sm:grid-text-right">
                 <h3 class="title">
                     Laravel Package Training
-                    <div class="title-subtext text-pink-dark">
+                    <span class="title-subtext text-pink-dark block">
                         <span class="font-normal">4 hours of </span>premium video content
-                    </div>
+                    </span>
                 </h3>
                 <p class="text-lg">
                     Having produced over 200 packages with more than 75 million downloads in total, we know what we're talking about when it comes to developing reusable components. Now is the time to look over our shoulders!
@@ -140,9 +140,9 @@
             <div class="markup links-blue links-underline">
                 <h3 class="title">
                     Soundcloud Demo Platform
-                    <div class="title-subtext text-pink-dark">
+                    <span class="title-subtext text-pink-dark block">
                         <span class="font-normal">Using</span> Soundcloud, Laravel, Vue
-                    </div>
+                    </span>
                 </h3>
                 <p class="text-lg">
                     For Martin Garrix' record label <a href="https://stmpdrcrds.com" target="_blank" rel="nofollow noreferrer noopener">stmpdrcrds.com</a> we made a workflow application to

--- a/resources/views/front/pages/open-source/partials/insights.blade.php
+++ b/resources/views/front/pages/open-source/partials/insights.blade.php
@@ -1,8 +1,8 @@
 <h2 class="title-sm">
     Latest insights
-    <div class="title-subtext text-pink-dark">
+    <span class="title-subtext text-pink-dark block">
         From the team
-    </div>
+    </span>
 </h2>
 @foreach ($insights as $insight)
      <p class="mt-4">

--- a/resources/views/front/pages/vacancies/partials/jobs.blade.php
+++ b/resources/views/front/pages/vacancies/partials/jobs.blade.php
@@ -3,18 +3,18 @@
         <div class="sm:col-span-3 | line-l">
             <h2 class="title-sm">
                 Vacancies at Spatie
-                <div class="title-subtext text-pink-dark">
+                <span class="title-subtext text-pink-dark block">
                    Currently looking for…
-                </div>
+                </span>
             </h2>
             @include('front.pages.vacancies.partials.list')
         </div>
         <div class="sm:col-span-3 | line-l">
             <h2 class="title-sm">
                 Internships
-                <div class="title-subtext text-pink-dark">
+                <span class="title-subtext text-pink-dark block">
                     Backend or frontend
-                </div>
+                </span>
             </h2>
             <p class="mt-4">
                 Are you looking to get really good in Laravel, Vue.js, PostCSS or Tailwind? We have slots available for students.


### PR DESCRIPTION
Replaced non-allowed `<div>` inside of `<h2>`- and `<h3>`-tags with block styled `<span>`.

W3 validator issues fixed:
* Element div not allowed as child of element h2 in this context. 
* Element div not allowed as child of element h3 in this context. 

Note:
`news.blade.php `had formatting issues in the same `<div>`-element. Decided to not create a separate PR for that.