### PR TITLE
Remove navigation role from header; use nav elements instead

### DIFF
--- a/resources/views/layout/partials/header.blade.php
+++ b/resources/views/layout/partials/header.blade.php
@@ -1,4 +1,4 @@
-<header class="pt-8 flex-none z-10 | md:bg-white md:shadow-light md:py-8 | print:bg-transparent print:shadow-none" role="navigation">
+<header class="pt-8 flex-none z-10 | md:bg-white md:shadow-light md:py-8 | print:bg-transparent print:shadow-none">
     <div class="wrap leading-loose | md:leading-none md:flex md:items-stretch">
         <a class="flex-shrink-0 logo h-8 w-20 mr-16 mb-8 block | md:mb-0 md:w-48 md:h-auto" href="/" title="Home">
             <span class="absolute h-full w-auto">
@@ -6,16 +6,15 @@
             </span>
         </a>
         <div class="grid grid-cols-2 items-start col-gap-8 | md:grid-cols-1 md:row-gap-6 md:justify-end md:justify-items-end md:ml-auto">
-            <div class="flex links links-black | md:row-start-2">
+            <nav class="flex links links-black | md:row-start-2">
                 @include('layout.partials.menu')
-            </div>
-            <div class="grid links links-black | md:opacity-75 md:row-start-1 md:grid-flow-col md:items-center md:gap-6 md:text-xs | print:hidden">
+            </nav>
+            <nav class="grid links links-black | md:opacity-75 md:row-start-1 md:grid-flow-col md:items-center md:gap-6 md:text-xs | print:hidden">
                 @include('layout.partials.service')
-            </div>
+            </nav>
         </div>
     </div>
     <div class="wrap | md:hidden | print:hidden">
         <hr class="mt-8 h-2px opacity-25 rounded text-gray">
     </div>
 </header>
-


### PR DESCRIPTION
No CSS declarations were affected.

W3 validator issue fixed:
* Bad value navigation for attribute role on element header.