### PR TITLE
Add getting started + Ray download

### DIFF
--- a/app/Http/Controllers/DownloadRayController.php
+++ b/app/Http/Controllers/DownloadRayController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Product;
+use App\Models\Purchase;
+use App\Services\Ray\Ray;
+use Illuminate\Http\Request;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+class DownloadRayController
+{
+    public function __invoke(Request $request, Ray $ray, string $platform)
+    {
+        abort_unless(in_array($platform, [
+            'macos',
+            'windows',
+            'linux',
+        ]), 404);
+
+        return redirect()->to($ray->getDownloadLink($platform));
+    }
+}

--- a/app/Nova/Filters/ProductFilter.php
+++ b/app/Nova/Filters/ProductFilter.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Nova\Filters;
+
+use App\Models\Product;
+use Illuminate\Http\Request;
+use Laravel\Nova\Filters\Filter;
+
+class ProductFilter extends Filter
+{
+    public $component = 'select-filter';
+
+    public function apply(Request $request, $query, $value)
+    {
+        return $query->where('product_id', $value);
+    }
+
+    public function options(Request $request)
+    {
+        return Product::pluck('id', 'title')->toArray();
+    }
+}

--- a/app/Services/Ray/Ray.php
+++ b/app/Services/Ray/Ray.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Services\Ray;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+use Symfony\Component\Yaml\Yaml;
+
+class Ray
+{
+    protected $baseUrl = 'https://ray-app.s3.eu-west-1.amazonaws.com';
+
+    public function getDownloadLink(string $platform)
+    {
+        $method = "getDownloadLink" . ucfirst(strtolower($platform));
+
+        return $this->$method();
+    }
+
+    public function latestMacosVersion(): string
+    {
+        return Cache::remember('latest-mac-version', 60, function () {
+            $yaml = Http::get("{$this->baseUrl}/latest-mac.yml")->body();
+
+            return Yaml::parse($yaml)['version'];
+        });
+    }
+
+    public function getDownloadLinkMacos(): string
+    {
+        $latestVersion = $this->latestMacosVersion();
+
+        return "{$this->baseUrl}/Ray-{$latestVersion}.dmg";
+    }
+
+    public function latestWindowsVersion(): string
+    {
+        return Cache::remember('latest-windows-version', 60, function () {
+            $yaml = Http::get("{$this->baseUrl}/latest.yml")->body();
+
+            return Yaml::parse($yaml)['version'];
+        });
+    }
+
+    public function getDownloadLinkWindows(): string
+    {
+        $latestVersion = $this->latestWindowsVersion();
+
+        return "{$this->baseUrl}/Ray Setup {$latestVersion}.exe";
+    }
+
+    public function latestLinuxVersion(): string
+    {
+        return Cache::remember('latest-linux-version', 60, function () {
+            $yaml = Http::get("{$this->baseUrl}/latest.yml")->body();
+
+            return Yaml::parse($yaml)['version'];
+        });
+    }
+
+    public function getDownloadLinkLinux(): string
+    {
+        $latestVersion = $this->latestLinuxVersion();
+
+        return "{$this->baseUrl}Ray-{$latestVersion}.AppImage";
+    }
+}

--- a/database/migrations/2021_01_08_120639_add_getting_started_description_to_purchasables_table.php
+++ b/database/migrations/2021_01_08_120639_add_getting_started_description_to_purchasables_table.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddGettingStartedDescriptionToPurchasablesTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('purchasables', function (Blueprint $table) {
+            $table->text('getting_started_description')->after('getting_started_url')->nullable();
+        });
+    }
+}

--- a/resources/views/front/pages/products/detail/default.blade.php
+++ b/resources/views/front/pages/products/detail/default.blade.php
@@ -39,6 +39,8 @@
                             <br /><br />
                             Here's a little bonus: you will get 10% discount on purchases in the next 24 hours!
 
+                            {!! $purchasable->getting_started_description ?? '' !!}
+
                             @if ($purchasable->getting_started_url)
                                 <br>
                                 <a class="link-white link-underline" href="{{ $purchasable->getting_started_url }}">

--- a/resources/views/front/pages/products/partials/purchasedLicense.blade.php
+++ b/resources/views/front/pages/products/partials/purchasedLicense.blade.php
@@ -1,5 +1,6 @@
 <div class="cells grid-cols-auto-1fr">
     <div class="cell-l">
+        {!! $license->purchasable->getting_started_description ?? '' !!}
         <div class="grid grid-flow-col gap-4 justify-start">
             @if ($license->purchasable->getting_started_url)
                 <a class="link-blue link-underline" href="{{ $license->purchasable->getting_started_url }}">

--- a/resources/views/front/pages/products/partials/purchasedProduct.blade.php
+++ b/resources/views/front/pages/products/partials/purchasedProduct.blade.php
@@ -5,7 +5,7 @@
 
 <div class="cells">
     <div class="cell-l">
-
+        {!! $purchasable->getting_started_description ?? '' !!}
         <div class="grid grid-flow-col gap-4 justify-start">
             @if ($purchasable->getting_started_url)
                 <a class="link-blue link-underline" href="{{ $purchasable->getting_started_url }}">
@@ -18,7 +18,7 @@
                     Videos
                 </a>
             @endif
-            
+
             @foreach($purchasable->getMedia('downloads') as $download)
                     @php
                         $downloadUrl =  URL::temporarySignedRoute(
@@ -51,6 +51,6 @@
             <span class="char-searator mx-1">•</span>
             Purchased on {{ $purchase->created_at->format('Y-m-d') }}
         </div>
-        
+
     </div>
 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,7 @@ use App\Http\Auth\Controllers\UpdatePasswordController;
 use App\Http\Controllers\BlogsController;
 use App\Http\Controllers\DocsController;
 use App\Http\Controllers\DownloadPurchasableController;
+use App\Http\Controllers\DownloadRayController;
 use App\Http\Controllers\ShowReleaseNotesController;
 use App\Http\Controllers\SignedProductLicenseController;
 use App\Http\Controllers\GitHubSocialiteController;
@@ -59,6 +60,8 @@ Route::prefix('about-us')->group(function () {
 Route::prefix('products')->group(function () {
     Route::get('/', [ProductsController::class, 'index'])->name('products.index');
     Route::get('{product:slug}', [ProductsController::class, 'show'])->name('products.show');
+
+    Route::get('ray/download/{platform}/latest', DownloadRayController::class);
 
     Route::get('{product:slug}/purchasables/{purchasable}/purchase-complete', AfterPaddleSaleController::class);
 


### PR DESCRIPTION
This adds the following urls to spatie.be:

https://spatie.be/products/ray/download/macos/latest
https://spatie.be/products/ray/download/windows/latest
https://spatie.be/products/ray/download/linux/latest

And also adds a "Getting started description" field that allows HTML for a getting started guide of a purchasable which appears before the "Getting started url".

![image](https://user-images.githubusercontent.com/3626559/104009929-0e3c7500-51ac-11eb-95bd-eab3d9c00734.png)


