### PR TITLE
Update laravel-permissions docs version

### DIFF
--- a/config/docs.php
+++ b/config/docs.php
@@ -148,7 +148,8 @@ return [
             "name" => "laravel-permission",
             "repository" => "spatie/laravel-permission",
             "branches" => [
-                "master" => "v3",
+                "master" => "v4",
+                "v3" => "v3",
                 "v2" => "v2",
             ],
             "category" => "Laravel",


### PR DESCRIPTION
v4 has been tagged, so updating docs to display accordingly.

NOTE: someone at Spatie needs to edit the repo's "link" to point to v4 docs instead of v3 
https://github.com/spatie/laravel-permission

![spatielaravel-permission: Associate users with roles and permissions 2021-01-27 at 6 10 50 PM](https://user-images.githubusercontent.com/404472/106066601-19a7ff80-60cb-11eb-9862-213fee658aba.jpg)

// cc @riasvdv  @freekmurze 