### PR TITLE
Add a second notification for expired licenses

### DIFF
--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -24,6 +24,7 @@ class License extends Model implements AuthenticatableContract
         'satis_authentication_count' => 'integer',
         'expiration_warning_mail_sent_at' => 'datetime',
         'expiration_mail_sent_at' => 'datetime',
+        'second_expiration_mail_sent_at' => 'datetime',
     ];
 
     public static function booted()
@@ -82,6 +83,7 @@ class License extends Model implements AuthenticatableContract
             'expires_at' => $this->expirationDateWhenRenewed(),
             'expiration_warning_mail_sent_at' => null,
             'expiration_mail_sent_at' => null,
+            'second_expiration_mail_sent_at' => null,
         ];
 
         $this->update($attributes);

--- a/app/Notifications/LicenseExpiredNotification.php
+++ b/app/Notifications/LicenseExpiredNotification.php
@@ -36,6 +36,7 @@ class LicenseExpiredNotification extends Notification
             ->greeting('Hi!')
             ->line("Just a reminder to inform you that your {$name} license has expired.")
             ->line("If you want to keep receiving updates, go to the license overview on the [spatie.be]({$siteUrl}) site to renew the license.")
+            ->line($this->license->purchasable->renewal_mail_incentive)
             ->action('Renew now', action([ProductsController::class, 'show'], $this->license->purchasable->product))
             ->line("Thank you for using {$this->license->purchasable->product->title}!");
     }

--- a/app/Notifications/LicenseExpiredNotification.php
+++ b/app/Notifications/LicenseExpiredNotification.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\ProductsController;
 use App\Models\License;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Markdown;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
@@ -36,7 +37,7 @@ class LicenseExpiredNotification extends Notification
             ->greeting('Hi!')
             ->line("Just a reminder to inform you that your {$name} license has expired.")
             ->line("If you want to keep receiving updates, go to the license overview on the [spatie.be]({$siteUrl}) site to renew the license.")
-            ->line($this->license->purchasable->renewal_mail_incentive)
+            ->line(Markdown::parse($this->license->purchasable->renewal_mail_incentive))
             ->action('Renew now', action([ProductsController::class, 'show'], $this->license->purchasable->product))
             ->line("Thank you for using {$this->license->purchasable->product->title}!");
     }

--- a/app/Notifications/LicenseExpiredNotification.php
+++ b/app/Notifications/LicenseExpiredNotification.php
@@ -34,9 +34,9 @@ class LicenseExpiredNotification extends Notification
         return (new MailMessage)
             ->subject("Your {$name} license has expired")
             ->greeting('Hi!')
-            ->line("Your {$name} license has expired")
-            ->line("If you want to keep receiving updates, go to the license overview on the [spatie.be]({$siteUrl}) site to renew the license")
-            ->action('License overview', action([ProductsController::class, 'show'], $this->license->purchasable->product))
+            ->line("Just a reminder to inform you that your {$name} license has expired.")
+            ->line("If you want to keep receiving updates, go to the license overview on the [spatie.be]({$siteUrl}) site to renew the license.")
+            ->action('Renew now', action([ProductsController::class, 'show'], $this->license->purchasable->product))
             ->line("Thank you for using {$this->license->purchasable->product->title}!");
     }
 }

--- a/app/Notifications/LicenseExpiredSecondNotification.php
+++ b/app/Notifications/LicenseExpiredSecondNotification.php
@@ -33,10 +33,11 @@ class LicenseExpiredSecondNotification extends Notification
 
         return (new MailMessage)
             ->subject("Your {$name} license has expired")
-            ->greeting('Hi!')
-            ->line("Your {$name} license has expired")
-            ->line("If you want to keep receiving updates, go to the license overview on the [spatie.be]({$siteUrl}) site to renew the license")
-            ->action('License overview', action([ProductsController::class, 'show'], $this->license->purchasable->product))
+            ->greeting('Hi again!')
+            ->line("A quick -and last- reminder to tell you that your {$name} license has expired now.")
+            ->line("At this point, you won't be receiving future updates for {$name}.")
+            ->line("You can visit the license overview on the [spatie.be]({$siteUrl}) site anytime to reactivate updates.")
+            ->action('Renew now', action([ProductsController::class, 'show'], $this->license->purchasable->product))
             ->line("Thank you for using {$this->license->purchasable->product->title}!");
     }
 }

--- a/app/Notifications/LicenseExpiredSecondNotification.php
+++ b/app/Notifications/LicenseExpiredSecondNotification.php
@@ -37,6 +37,7 @@ class LicenseExpiredSecondNotification extends Notification
             ->line("A quick -and last- reminder to tell you that your {$name} license has expired now.")
             ->line("At this point, you won't be receiving future updates for {$name}.")
             ->line("You can visit the license overview on the [spatie.be]({$siteUrl}) site anytime to reactivate updates.")
+            ->line($this->license->purchasable->renewal_mail_incentive)
             ->action('Renew now', action([ProductsController::class, 'show'], $this->license->purchasable->product))
             ->line("Thank you for using {$this->license->purchasable->product->title}!");
     }

--- a/app/Notifications/LicenseExpiredSecondNotification.php
+++ b/app/Notifications/LicenseExpiredSecondNotification.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\ProductsController;
 use App\Models\License;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Markdown;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
@@ -37,7 +38,7 @@ class LicenseExpiredSecondNotification extends Notification
             ->line("A quick -and last- reminder to tell you that your {$name} license has expired now.")
             ->line("At this point, you won't be receiving future updates for {$name}.")
             ->line("You can visit the license overview on the [spatie.be]({$siteUrl}) site anytime to reactivate updates.")
-            ->line($this->license->purchasable->renewal_mail_incentive)
+            ->line(Markdown::parse($this->license->purchasable->renewal_mail_incentive))
             ->action('Renew now', action([ProductsController::class, 'show'], $this->license->purchasable->product))
             ->line("Thank you for using {$this->license->purchasable->product->title}!");
     }

--- a/app/Notifications/LicenseExpiredSecondNotification.php
+++ b/app/Notifications/LicenseExpiredSecondNotification.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Http\Controllers\ProductsController;
+use App\Models\License;
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class LicenseExpiredSecondNotification extends Notification
+{
+    use Queueable;
+
+    private License $license;
+
+    public function __construct(License $license)
+    {
+        $this->license = $license;
+    }
+
+    public function via($notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(User $notifiable): MailMessage
+    {
+        $name = $this->license->getName();
+
+        $siteUrl = url('/');
+
+        return (new MailMessage)
+            ->subject("Your {$name} license has expired")
+            ->greeting('Hi!')
+            ->line("Your {$name} license has expired")
+            ->line("If you want to keep receiving updates, go to the license overview on the [spatie.be]({$siteUrl}) site to renew the license")
+            ->action('License overview', action([ProductsController::class, 'show'], $this->license->purchasable->product))
+            ->line("Thank you for using {$this->license->purchasable->product->title}!");
+    }
+}

--- a/app/Notifications/LicenseIsAboutToExpireNotification.php
+++ b/app/Notifications/LicenseIsAboutToExpireNotification.php
@@ -34,9 +34,9 @@ class LicenseIsAboutToExpireNotification extends Notification
         return (new MailMessage)
             ->subject("Your {$name} license is about to expire")
             ->greeting('Hi!')
-            ->line("Your {$name} license expires on {$this->license->expires_at->format('Y-m-d')}")
-            ->line("Go to your license overview on the [spatie.be]({$siteUrl}) site to renew the license and continue receiving updates")
-            ->action('License overview', action([ProductsController::class, 'show'], $this->license->purchasable->product))
+            ->line("Your {$name} license expires on {$this->license->expires_at->format('Y-m-d')}.")
+            ->line("Go to your license overview on the [spatie.be]({$siteUrl}) site to renew the license and continue receiving updates.")
+            ->action('Renew now', action([ProductsController::class, 'show'], $this->license->purchasable->product))
             ->line("Thank you for using {$this->license->purchasable->product->title}!");
     }
 }

--- a/app/Notifications/LicenseIsAboutToExpireNotification.php
+++ b/app/Notifications/LicenseIsAboutToExpireNotification.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\ProductsController;
 use App\Models\License;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Markdown;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
@@ -36,7 +37,7 @@ class LicenseIsAboutToExpireNotification extends Notification
             ->greeting('Hi!')
             ->line("Your {$name} license expires on {$this->license->expires_at->format('Y-m-d')}.")
             ->line("Go to your license overview on the [spatie.be]({$siteUrl}) site to renew the license and continue receiving updates.")
-            ->line($this->license->purchasable->renewal_mail_incentive)
+            ->line(Markdown::parse($this->license->purchasable->renewal_mail_incentive))
             ->action('Renew now', action([ProductsController::class, 'show'], $this->license->purchasable->product))
             ->line("Thank you for using {$this->license->purchasable->product->title}!");
     }

--- a/app/Notifications/LicenseIsAboutToExpireNotification.php
+++ b/app/Notifications/LicenseIsAboutToExpireNotification.php
@@ -36,6 +36,7 @@ class LicenseIsAboutToExpireNotification extends Notification
             ->greeting('Hi!')
             ->line("Your {$name} license expires on {$this->license->expires_at->format('Y-m-d')}.")
             ->line("Go to your license overview on the [spatie.be]({$siteUrl}) site to renew the license and continue receiving updates.")
+            ->line($this->license->purchasable->renewal_mail_incentive)
             ->action('Renew now', action([ProductsController::class, 'show'], $this->license->purchasable->product))
             ->line("Thank you for using {$this->license->purchasable->product->title}!");
     }

--- a/app/Nova/Purchasable.php
+++ b/app/Nova/Purchasable.php
@@ -118,6 +118,8 @@ class Purchasable extends Resource
 
                 Markdown::make('Description'),
 
+                Markdown::make('Renewal mail incentive'),
+
                 Files::make('Downloads')
                     ->customPropertiesFields([
                         Text::make('Label'),

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -44,6 +44,12 @@ class RouteServiceProvider extends ServiceProvider
         Route::middleware(['web'])
             ->group(base_path('routes/web.php'));
 
+        if ($this->app->environment('local')) {
+            Route::middleware(['web'])
+                ->prefix('dev')
+                ->group(base_path('routes/dev.php'));
+        }
+
         return $this;
     }
 

--- a/database/migrations/2021_07_02_123209_add_second_expiration_mail_sent_at_to_licenses_table.php
+++ b/database/migrations/2021_07_02_123209_add_second_expiration_mail_sent_at_to_licenses_table.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddSecondExpirationMailSentAtToLicensesTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('licenses', function (Blueprint $table) {
+            $table->dateTime('second_expiration_mail_sent_at')->after('expiration_mail_sent_at')->nullable();
+        });
+    }
+}

--- a/database/migrations/2021_07_07_095747_add_renewal_mail_incentive_to_purchasables_table.php
+++ b/database/migrations/2021_07_07_095747_add_renewal_mail_incentive_to_purchasables_table.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddRenewalMailIncentiveToPurchasablesTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('purchasables', function (Blueprint $table) {
+            $table->text('renewal_mail_incentive')->nullable()->after('description');
+        });
+    }
+}

--- a/resources/views/vendor/mail/html/message.blade.php
+++ b/resources/views/vendor/mail/html/message.blade.php
@@ -1,0 +1,27 @@
+@component('mail::layout')
+{{-- Header --}}
+@slot('header')
+@component('mail::header', ['url' => config('app.url')])
+    <img width="570" src="{{ asset('images/email/header.jpg') }}" alt="">
+@endcomponent
+@endslot
+
+{{-- Body --}}
+{{ $slot }}
+
+{{-- Subcopy --}}
+@isset($subcopy)
+@slot('subcopy')
+@component('mail::subcopy')
+{{ $subcopy }}
+@endcomponent
+@endslot
+@endisset
+
+{{-- Footer --}}
+@slot('footer')
+@component('mail::footer')
+© {{ date('Y') }} {{ config('app.name') }}. @lang('All rights reserved.')
+@endcomponent
+@endslot
+@endcomponent

--- a/resources/views/vendor/mail/html/themes/default.css
+++ b/resources/views/vendor/mail/html/themes/default.css
@@ -1,0 +1,294 @@
+/* Base */
+
+body,
+body *:not(html):not(style):not(br):not(tr):not(code) {
+    box-sizing: border-box;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif,
+        'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+    position: relative;
+}
+
+body {
+    -webkit-text-size-adjust: none;
+    background-color: #ffffff;
+    color: #718096;
+    height: 100%;
+    line-height: 1.4;
+    margin: 0;
+    padding: 0;
+    width: 100% !important;
+}
+
+p,
+ul,
+ol,
+blockquote {
+    line-height: 1.4;
+    text-align: left;
+}
+
+a {
+    color: #0e7a99;
+}
+
+a img {
+    border: none;
+}
+
+/* Typography */
+
+h1 {
+    color: #3d4852;
+    font-size: 18px;
+    font-weight: bold;
+    margin-top: 0;
+    text-align: left;
+}
+
+h2 {
+    font-size: 16px;
+    font-weight: bold;
+    margin-top: 0;
+    text-align: left;
+}
+
+h3 {
+    font-size: 14px;
+    font-weight: bold;
+    margin-top: 0;
+    text-align: left;
+}
+
+p {
+    font-size: 16px;
+    line-height: 1.5em;
+    margin-top: 0;
+    text-align: left;
+}
+
+p.sub {
+    font-size: 12px;
+}
+
+img {
+    max-width: 100%;
+}
+
+/* Layout */
+
+.wrapper {
+    -premailer-cellpadding: 0;
+    -premailer-cellspacing: 0;
+    -premailer-width: 100%;
+    background-color: #edf2f7;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+}
+
+.content {
+    -premailer-cellpadding: 0;
+    -premailer-cellspacing: 0;
+    -premailer-width: 100%;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+}
+
+/* Header */
+
+.header {
+    padding: 25px 0 0;
+    text-align: center;
+    border-top-left-radius: 2px;
+    border-top-right-radius: 2px;
+}
+
+.header a {
+    color: #3d4852;
+    font-size: 19px;
+    font-weight: bold;
+    text-decoration: none;
+}
+
+/* Logo */
+
+.logo {
+    height: 75px;
+    max-height: 75px;
+    width: 75px;
+}
+
+/* Body */
+
+.body {
+    -premailer-cellpadding: 0;
+    -premailer-cellspacing: 0;
+    -premailer-width: 100%;
+    background-color: #edf2f7;
+    border-bottom: 1px solid #edf2f7;
+    border-top: 1px solid #edf2f7;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+}
+
+.inner-body {
+    -premailer-cellpadding: 0;
+    -premailer-cellspacing: 0;
+    -premailer-width: 570px;
+    background-color: #ffffff;
+    border-color: #e8e5ef;
+    border-bottom-left-radius: 2px;
+    border-bottom-right-radius: 2px;
+    border-width: 1px;
+    border-top: 0;
+    box-shadow: 0 2px 0 rgba(0, 0, 150, 0.025), 2px 4px 0 rgba(0, 0, 150, 0.015);
+    margin: 0 auto;
+    padding: 0;
+    width: 570px;
+}
+
+/* Subcopy */
+
+.subcopy {
+    border-top: 1px solid #e8e5ef;
+    margin-top: 25px;
+    padding-top: 25px;
+}
+
+.subcopy p {
+    font-size: 14px;
+}
+
+/* Footer */
+
+.footer {
+    -premailer-cellpadding: 0;
+    -premailer-cellspacing: 0;
+    -premailer-width: 570px;
+    margin: 0 auto;
+    padding: 0;
+    text-align: center;
+    width: 570px;
+}
+
+.footer p {
+    color: #b0adc5;
+    font-size: 12px;
+    text-align: center;
+}
+
+.footer a {
+    color: #b0adc5;
+    text-decoration: underline;
+}
+
+/* Tables */
+
+.table table {
+    -premailer-cellpadding: 0;
+    -premailer-cellspacing: 0;
+    -premailer-width: 100%;
+    margin: 30px auto;
+    width: 100%;
+}
+
+.table th {
+    border-bottom: 1px solid #edeff2;
+    margin: 0;
+    padding-bottom: 8px;
+}
+
+.table td {
+    color: #74787e;
+    font-size: 15px;
+    line-height: 18px;
+    margin: 0;
+    padding: 10px 0;
+}
+
+.content-cell {
+    max-width: 100vw;
+    padding: 32px;
+}
+
+/* Buttons */
+
+.action {
+    -premailer-cellpadding: 0;
+    -premailer-cellspacing: 0;
+    -premailer-width: 100%;
+    margin: 30px auto;
+    padding: 0;
+    text-align: center;
+    width: 100%;
+}
+
+.button {
+    -webkit-text-size-adjust: none;
+    border-radius: 4px;
+    color: #fff;
+    display: inline-block;
+    overflow: hidden;
+    text-decoration: none;
+}
+
+.button-blue,
+.button-primary {
+    background-color: #0e7a99;
+    border-bottom: 8px solid #0e7a99;
+    border-left: 18px solid #0e7a99;
+    border-right: 18px solid #0e7a99;
+    border-top: 8px solid #0e7a99;
+}
+
+.button-green,
+.button-success {
+    background-color: #48bb78;
+    border-bottom: 8px solid #48bb78;
+    border-left: 18px solid #48bb78;
+    border-right: 18px solid #48bb78;
+    border-top: 8px solid #48bb78;
+}
+
+.button-red,
+.button-error {
+    background-color: #e53e3e;
+    border-bottom: 8px solid #e53e3e;
+    border-left: 18px solid #e53e3e;
+    border-right: 18px solid #e53e3e;
+    border-top: 8px solid #e53e3e;
+}
+
+/* Panels */
+
+.panel {
+    border-left: #2d3748 solid 4px;
+    margin: 21px 0;
+}
+
+.panel-content {
+    background-color: #edf2f7;
+    color: #718096;
+    padding: 16px;
+}
+
+.panel-content p {
+    color: #718096;
+}
+
+.panel-item {
+    padding: 0;
+}
+
+.panel-item p:last-of-type {
+    margin-bottom: 0;
+    padding-bottom: 0;
+}
+
+/* Utilities */
+
+.break-all {
+    word-break: break-all;
+}

--- a/routes/dev.php
+++ b/routes/dev.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Models\License;
+use App\Models\User;
+use App\Notifications\LicenseExpiredNotification;
+use App\Notifications\LicenseExpiredSecondNotification;
+use App\Notifications\LicenseIsAboutToExpireNotification;
+
+Route::prefix('mails')->group(function () {
+    Route::get('license-expires-soon', function () {
+        $notification = new LicenseIsAboutToExpireNotification(License::first());
+
+        return $notification->toMail(User::first());
+    });
+
+    Route::get('license-expired', function () {
+        $notification = new LicenseExpiredNotification(License::first());
+
+        return $notification->toMail(User::first());
+    });
+
+    Route::get('license-expired-second', function () {
+        $notification = new LicenseExpiredSecondNotification(License::first());
+
+        return $notification->toMail(User::first());
+    });
+});


### PR DESCRIPTION
I've added the scaffolding for a second notification.

The copy should probably be updated a bit.

We also want to add the advantages of the product you're renewing the license for. How do we want to do this? Do we add an extra field to the Purchasables in Nova? Something like "mail_advantages"?