### PR TITLE
Remove index.php from website (sometimes visible in seo results)

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -31,10 +31,24 @@ class RouteServiceProvider extends ServiceProvider
 
     public function map(): void
     {
+        $this->removeIndexPhpFromUrl();
+        
         $this
             ->mapWebRoutes()
             ->mapApiRoutes()
             ->mapRedirectsForOldSite();
+    }
+    
+    protected function removeIndexPhpFromUrl()
+    {
+        if (Str::contains(request()->getRequestUri(), '/index.php/')) {
+            $url = str_replace('index.php/', '', request()->getRequestUri());
+
+            if (strlen($url) > 0) {
+                header("Location: $url", true, 301);
+                exit;
+            }
+        }
     }
 
     protected function mapWebRoutes(): self


### PR DESCRIPTION
I searched for the `medialibrary` docs and found that this url (https://spatie.be/index.php/docs/laravel-medialibrary/v9/introduction on https://www.google.com/search?q=laravel+media+library) uses `index.php` in the search results (even though the `canonical` link is set, it uses a wrong variant). 

![CleanShot 2021-08-26 at 10 29 24@2x](https://user-images.githubusercontent.com/22446895/130929230-5392574d-6522-429f-8cec-dacd72d186ea.png)

Based on a blogpost by @mattiasgeniar (https://ma.ttias.be/remove-index-php-from-the-url-in-laravel/), it's possible to handle this in the `RouteServiceProvider`. 

If this isn't the way you want (in the application itself), it could also be done in nginx or something else.

For example in NGINX (thanks Mattias):
```
if ($request_uri ~* "^/index\.php(/?)(.*)") {
    return 301 $2;
}
```