### PR TITLE
fix hash doesn't have default value tests error

### DIFF
--- a/database/factories/VideoFactory.php
+++ b/database/factories/VideoFactory.php
@@ -18,6 +18,7 @@ class VideoFactory extends Factory
             'runtime' => 1,
             'thumbnail' => 'test',
             'sort_order' => 1,
+            'hash' => 'test',
         ];
     }
 }


### PR DESCRIPTION
Fix error: Field 'hash' doesn't have a default value