### PR TITLE
Update link to Paddle VAT instructions

### DIFF
--- a/resources/views/front/pages/products/buy/default.blade.php
+++ b/resources/views/front/pages/products/buy/default.blade.php
@@ -36,7 +36,7 @@
                 Includes a 10% coupon for a follow-up purchase within the next 24 hours.
                 <br/>
                 VAT will be calculated during checkout by
-                <a class="underline" target="_blank" href="https://paddle.com/support/welcome/#vat-tax-handling-and-compliance">Paddle</a>.
+                <a class="underline" target="_blank" href="https://www.paddle.com/help/sell/tax/how-paddle-handles-vat-on-your-behalf">Paddle</a>.
             </div>
         </div>
     </div>


### PR DESCRIPTION
Looks like the instructions for VAT handling by Paddle changed to this new support page.