### PR TITLE
Flare header

### DIFF
--- a/resources/views/layout/default.blade.php
+++ b/resources/views/layout/default.blade.php
@@ -36,6 +36,7 @@
 
     {{-- @include('layout.partials.cta') --}}
 
+    @include('layout.partials.header-alert')
     @include('layout.partials.header')
     @include('layout.partials.flash')
 

--- a/resources/views/layout/partials/header-alert.blade.php
+++ b/resources/views/layout/partials/header-alert.blade.php
@@ -1,0 +1,5 @@
+<div class="gradient gradient-pink text-white items-center justify-center p-2 text-center text-sm">
+    <div class="mt-px ml-1">
+        Launching a new design for <a href="https://flareapp.io" target="_blank" class="underline">Flare</a> mid March!
+    </div>
+</div>


### PR DESCRIPTION
<img width="1337" alt="Screenshot 2023-03-01 at 10 55 02" src="https://user-images.githubusercontent.com/10651054/222105944-29ca7aa7-46a5-4ef1-a9e1-f77699179286.png">

I used the pink from the Newsletter Subscribe card. 
Or do we want the header in the new Flare style?
