### PR TITLE
update Laravel-Permission branches

### DIFF
--- a/config/docs.php
+++ b/config/docs.php
@@ -232,7 +232,8 @@ return [
             "name" => "laravel-permission",
             "repository" => "spatie/laravel-permission",
             "branches" => [
-                "main" => "v5",
+                "v5" => "v5",
+                "main" => "v6",
                 "v4" => "v4",
                 "v3" => "v3",
             ],


### PR DESCRIPTION
Temporarily hiding v6(main) below v5 until v6 is actually released. Will re-order numerically at that time.