### PR TITLE
Render docs just-in-time

### DIFF
--- a/app/Console/Commands/ImportDocsFromRepositoriesCommand.php
+++ b/app/Console/Commands/ImportDocsFromRepositoriesCommand.php
@@ -87,12 +87,7 @@ class ImportDocsFromRepositoriesCommand extends Command
                     if (! $process->isSuccessful()) {
                         $this->error($repository['name'] . ': ' . $process->getErrorOutput());
                         report(new DocsImportException("Import for repository {$repository['name']} unsuccessful: " . $process->getErrorOutput()));
-
-                        return;
                     }
-
-                    cache()->store('docs')->forget($repository['name']);
-                    app(Docs::class)->getRepository($repository['name']);
                 };
             })
             ->toArray();

--- a/app/Console/Commands/ImportDocsFromRepositoriesCommand.php
+++ b/app/Console/Commands/ImportDocsFromRepositoriesCommand.php
@@ -2,7 +2,6 @@
 
 namespace App\Console\Commands;
 
-use App\Docs\Docs;
 use App\Exceptions\DocsImportException;
 use App\Support\ValueStores\UpdatedRepositoriesValueStore;
 use Illuminate\Console\Command;

--- a/app/Docs/DocumentationContentParser.php
+++ b/app/Docs/DocumentationContentParser.php
@@ -2,20 +2,8 @@
 
 namespace App\Docs;
 
-use App\Support\CommonMark\ImageRenderer;
-use App\Support\CommonMark\LinkRenderer;
-use Illuminate\Support\HtmlString;
-use League\CommonMark\Extension\CommonMark\Node\Block\FencedCode;
-use League\CommonMark\Extension\CommonMark\Node\Inline\Code;
-use League\CommonMark\Extension\CommonMark\Node\Inline\Image;
-use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
-use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkExtension;
-use League\CommonMark\Extension\Table\TableExtension;
-use Spatie\LaravelMarkdown\MarkdownRenderer;
 use Spatie\Sheets\ContentParsers\MarkdownWithFrontMatterParser;
 use Spatie\YamlFrontMatter\YamlFrontMatter;
-use Tempest\Highlight\CommonMark\CodeBlockRenderer;
-use Tempest\Highlight\CommonMark\InlineCodeBlockRenderer;
 
 class DocumentationContentParser extends MarkdownWithFrontMatterParser
 {

--- a/app/Docs/DocumentationContentParser.php
+++ b/app/Docs/DocumentationContentParser.php
@@ -19,35 +19,18 @@ use Tempest\Highlight\CommonMark\InlineCodeBlockRenderer;
 
 class DocumentationContentParser extends MarkdownWithFrontMatterParser
 {
-    protected MarkdownRenderer $markdownRenderer;
-
-    public function __construct()
-    {
-        $this->markdownRenderer = app(MarkdownRenderer::class)
-            ->highlightCode(false)
-            ->addExtension(new TableExtension())
-            ->addExtension(new HeadingPermalinkExtension())
-            ->addInlineRenderer(Image::class, new ImageRenderer())
-            ->addInlineRenderer(Link::class, new LinkRenderer())
-            ->addInlineRenderer(FencedCode::class, new CodeBlockRenderer(), 10)
-            ->addInlineRenderer(Code::class, new InlineCodeBlockRenderer(), 10)
-            ->commonmarkOptions([
-                'heading_permalink' => [
-                    'html_class' => 'anchor-link',
-                    'symbol' => '#',
-                ],
-            ]);
-    }
-
     public function parse(string $contents): array
     {
         $document = YamlFrontMatter::parse($contents);
 
-        $htmlContents = $this->markdownRenderer->toHtml($document->body());
-
         return array_merge(
             $document->matter(),
-            ['contents' => new HtmlString($htmlContents)]
+            /**
+             * We don't do any markdown parsing here and
+             * only when showing the page instead.
+             * @see \App\Http\Controllers\DocsController::show
+             */
+            ['contents' => $document->body()]
         );
     }
 }

--- a/config/docs.php
+++ b/config/docs.php
@@ -112,14 +112,6 @@ return [
             "category" => "Laravel",
         ],
         [
-            "name" => "ray",
-            "repository" => "spatie/ray",
-            "branches" => [
-                "main" => "v1",
-            ],
-            "category" => "General PHP",
-        ],
-        [
             "name" => "laravel-backup",
             "repository" => "spatie/laravel-backup",
             "branches" => [


### PR DESCRIPTION
Noticed spatie.be having some CPU issues, this renders the markdown of the docs when displaying, not when retrieving the Sheets instance (which would render every page)