### PR TITLE
Secures access to Filament by requiring a secret key in the URL.

### DIFF
--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -22,6 +22,7 @@ use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Session\Middleware\AuthenticateSession;
 use Illuminate\Session\Middleware\StartSession;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
+use Dasundev\FilamentAccessSecret\Middleware\VerifyAdminAccessSecret;
 
 class AdminPanelProvider extends PanelProvider
 {
@@ -50,6 +51,7 @@ class AdminPanelProvider extends PanelProvider
                 PurchasesPerPurchasablePerDayWidget::class,
             ])
             ->middleware([
+                VerifyAdminAccessSecret::class,
                 EncryptCookies::class,
                 AddQueuedCookiesToResponse::class,
                 StartSession::class,

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "aws/aws-sdk-php": "^3.240.6",
         "barryvdh/laravel-debugbar": "^3.8",
         "blade-ui-kit/blade-ui-kit": "^0.5",
+        "dasundev/filament-access-secret": "^3.0",
         "doctrine/dbal": "^3.5.1",
         "filament/filament": "^3.2",
         "filament/spatie-laravel-media-library-plugin": "^3.2",


### PR DESCRIPTION
I have installed a new package called `filament-access-secret`, which I developed myself to protect the filament panel with an additional security layer.

You can read more in the [README](https://github.com/dasundev/filament-access-secret?tab=readme-ov-file#filament-access-secret).

Once you merge this PR and it's deployed, you just have to add a new environment variable with a secret key as follows:

```env
DEFAULT_FILAMENT_ACCESS_SECRET_KEY="secret-key"
```

And then, the public cannot access the [https://spatie.be/admin](https://spatie.be/admin) URL without providing the secret key at the end of this URL: https://spatie.be/admin/my-secret