### PR TITLE
Replace polyfill CDN with Cloudflare cdnjs asap

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -15,7 +15,7 @@ self.addEventListener('install', event => {
                 // External request, avoid CORS troubles
                 [
                     'https://cloud.typography.com/6194432/6145752/css/fonts.css',
-                    'https://polyfill.io/v2/polyfill.min.js?features=IntersectionObserver',
+                    'https://cdnjs.cloudflare.com/polyfill/v2/polyfill.min.js?features=IntersectionObserver',
                 ].map(url => {
                     const request = new Request(url, { mode: 'no-cors' });
                     fetch(request).then(response => cache.put(request, response));

--- a/resources/views/layout/default.blade.php
+++ b/resources/views/layout/default.blade.php
@@ -12,7 +12,7 @@
 
     @vite(['resources/js/front/app.js'])
 
-    <script src="https://polyfill.io/v2/polyfill.min.js?features=IntersectionObserver,Promise,Array.from,Element.prototype.dataset" defer></script>
+    <script src="https://cdnjs.cloudflare.com/polyfill/v2/polyfill.min.js?features=IntersectionObserver,Promise,Array.from,Element.prototype.dataset" defer></script>
 
     @include('layout.partials.analytics')
 


### PR DESCRIPTION
polyfill.io is compromised.

 [polyfill.io now available on cdnjs: reduce your supply chain risk](https://blog.cloudflare.com/polyfill-io-now-available-on-cdnjs-reduce-your-supply-chain-risk)
 
 https://x.com/triblondon/status/1761852117579427975
 
[malicious javascript injected into 100,000 websites ](https://www.youtube.com/watch?v=bbatLr98fEY)


This updates [Polyfill.io] scripts  to [cdnjs's polyfill service](https://cdnjs.cloudflare.com/polyfill/), which is a deployment that is identical to the original Polyfill.io service.

@freekmurze