### PR TITLE
chore: change laravel-php-guidelines.md path

### DIFF
--- a/resources/views/front/pages/guidelines/pages/ai.md
+++ b/resources/views/front/pages/guidelines/pages/ai.md
@@ -49,7 +49,7 @@ touch CLAUDE.md
 curl -o laravel-php-guidelines.md https://spatie.be/laravel-php-ai-guidelines.md
 
 # Tell Claude to read the guidelines file
-echo -e '\n## Coding Standards\nWhen working on this Laravel/PHP project, first read the coding guidelines at @laravel-php-guidelines.md' >> CLAUDE.md
+echo -e '\n## Coding Standards\nWhen working on this Laravel/PHP project, first read the coding guidelines at @docs/laravel-php-guidelines.md' >> CLAUDE.md
 ```
 
 Optionally, you can create a Composer script to keep guidelines updated:


### PR DESCRIPTION
The CURL command saves the laravel-php-guidelines.md into ./docs/laravel-php-guidelines.md This commit fix the instructions, using the full path.

_When working on this Laravel/PHP project, first read the coding guidelines at @docs/laravel-php-guidelines.md_