### PR TITLE
Fix stale discount campaign labels

### DIFF
--- a/app/Domain/Shop/Traits/HasPrices.php
+++ b/app/Domain/Shop/Traits/HasPrices.php
@@ -37,10 +37,7 @@ trait HasPrices
 
             $discountPercentage = 0;
 
-            if (now()->between(
-                $this->discount_starts_at ?? now()->subMinute(),
-                $this->discount_expires_at ?? now()->addMinute(),
-            )) {
+            if ($this->hasActivePurchasableDiscount()) {
                 $discountPercentage = $this->discount_percentage;
             }
 
@@ -125,6 +122,11 @@ trait HasPrices
             }
         }
 
+        return $this->hasActivePurchasableDiscount();
+    }
+
+    public function hasActivePurchasableDiscount(): bool
+    {
         if (! $this->discount_name) {
             return false;
         }
@@ -149,7 +151,9 @@ trait HasPrices
             }
         }
 
-        $purchasableDiscountExpiresAt = $this->discount_expires_at ?? now()->subSecond();
+        $purchasableDiscountExpiresAt = $this->hasActivePurchasableDiscount()
+            ? $this->discount_expires_at ?? now()->addMinute()
+            : now()->subSecond();
 
         return $userDiscountExpiresAt->isAfter($purchasableDiscountExpiresAt)
             ? $userDiscountExpiresAt
@@ -160,9 +164,7 @@ trait HasPrices
     {
         $percentage = 0;
 
-        $purchasableDiscountExpiresAt = $this->discount_expires_at ?? now()->addSecond();
-
-        if ($purchasableDiscountExpiresAt->isFuture()) {
+        if ($this->hasActivePurchasableDiscount()) {
             $percentage += $this->discount_percentage ?? 0;
         }
 

--- a/resources/views/front/pages/products/partials/priceCard.blade.php
+++ b/resources/views/front/pages/products/partials/priceCard.blade.php
@@ -34,7 +34,7 @@
         @endif
 
         <div class="-mx-6 px-2 py-3 bg-oss-green/10 mt-4 text-oss-green-pale text-sm text-center">
-            @if ($purchasable->discount_name)
+            @if ($purchasable->hasActivePurchasableDiscount())
                 <span>{{ $purchasable->discount_name }} <span class="char-separator">•</span> </span>
             @endif
             Now <span class="font-semibold">{{ $purchasable->displayableDiscountPercentage() }}%</span> off
@@ -293,4 +293,3 @@
         </div>
     </div>
 </div>
-

--- a/tests/Http/ProductDiscountLabelTest.php
+++ b/tests/Http/ProductDiscountLabelTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Domain\Shop\Models\Product;
+use App\Domain\Shop\Models\Purchasable;
+use App\Models\User;
+use Spatie\TestTime\TestTime;
+
+it('does not show an expired discount name for a personal discount', function () {
+    TestTime::freeze();
+
+    $user = User::factory()->create([
+        'next_purchase_discount_period_ends_at' => now()->addHour(),
+    ]);
+
+    $product = Product::factory()->create();
+
+    Purchasable::factory()->create([
+        'product_id' => $product->id,
+        'price_in_usd_cents' => 24900,
+        'discount_name' => 'BLACK FRIDAY',
+        'discount_percentage' => 30,
+        'discount_starts_at' => now()->subDays(10),
+        'discount_expires_at' => now()->subDay(),
+    ]);
+
+    $this
+        ->actingAs($user)
+        ->get(route('products.show', $product))
+        ->assertOk()
+        ->assertSeeText('Personal discount included!')
+        ->assertSeeTextInOrder(['Now', '10%', 'off', 'for you'])
+        ->assertDontSeeText('BLACK FRIDAY');
+});

--- a/tests/Unit/Models/PurchasableTest.php
+++ b/tests/Unit/Models/PurchasableTest.php
@@ -37,15 +37,41 @@ test('a discount can be valid during a certain period', function () {
 
     TestTime::addSeconds(59);
     expect($this->purchasable->hasActiveDiscount())->toBeFalse();
+    expect($this->purchasable->hasActivePurchasableDiscount())->toBeFalse();
 
     TestTime::addSecond();
     expect($this->purchasable->hasActiveDiscount())->toBeTrue();
+    expect($this->purchasable->hasActivePurchasableDiscount())->toBeTrue();
 
     TestTime::addHour()->subSecond();
     expect($this->purchasable->hasActiveDiscount())->toBeTrue();
+    expect($this->purchasable->hasActivePurchasableDiscount())->toBeTrue();
 
     TestTime::addSecond();
     expect($this->purchasable->hasActiveDiscount())->toBeFalse();
+    expect($this->purchasable->hasActivePurchasableDiscount())->toBeFalse();
+});
+
+test('an expired purchasable discount is not active when a personal discount is active', function () {
+    $this->user->update([
+        'next_purchase_discount_period_ends_at' => now()->addHour(),
+    ]);
+
+    $this->purchasable->update([
+        'discount_percentage' => 30,
+        'discount_name' => 'BLACK FRIDAY',
+        'discount_starts_at' => now()->subDays(10),
+        'discount_expires_at' => now()->subDay(),
+    ]);
+
+    expect($this->purchasable->hasActivePurchasableDiscount())->toBeFalse();
+
+    $this->actingAs($this->user);
+
+    expect($this->purchasable->hasActiveDiscount())->toBeTrue()
+        ->and($this->purchasable->hasActivePurchasableDiscount())->toBeFalse()
+        ->and($this->purchasable->displayableDiscountPercentage())->toEqual(10)
+        ->and($this->purchasable->getPriceForCountryCode('BE')->priceInCents)->toEqual(9000);
 });
 
 test('the next purchase discount on a user will be used', function () {


### PR DESCRIPTION
## Summary
- only show a purchasable campaign name when that purchasable discount is currently active
- keep personal/referrer discounts included in broad discount pricing without reusing expired campaign labels
- add regression coverage for a personal discount with an expired BLACK FRIDAY label

## Tests
- ./vendor/bin/pest --compact tests/Unit/Models/PurchasableTest.php tests/Http/ProductDiscountLabelTest.php

Note: local formatting command could not be run because this checkout does not have ./vendor/bin/pint or vendor/bin/php-cs-fixer installed.