### PR TITLE
Update profile purchases overview

### DIFF
--- a/app/Http/Controllers/PurchasesController.php
+++ b/app/Http/Controllers/PurchasesController.php
@@ -44,7 +44,7 @@ class PurchasesController
             ])
             ->whereHas('assignments', fn (Builder $query) => $query->where('user_id', '!=', $user->id))
             ->get()
-            ->sortByDesc(fn (Purchase $purchase) => $purchase->receipt?->paid_at ?? $purchase->created_at);
+            ->sortByDesc(fn (Purchase $purchase) => $purchase->receipt->paid_at ?? $purchase->created_at);
 
         return view('front.profile.purchases', compact('courses', 'applications', 'assignedAwayPurchases'));
     }

--- a/app/Http/Controllers/PurchasesController.php
+++ b/app/Http/Controllers/PurchasesController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Domain\Shop\Models\Purchase;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
@@ -10,27 +11,41 @@ class PurchasesController
 {
     public function __invoke(Request $request): View
     {
-        $courses = $request->user()
+        $user = $request->user();
+
+        $courses = $user
             ->assignmentsWithoutRenewals()
-            ->with(['purchasable.product', 'purchasable.media'])
+            ->with(['purchase.user', 'purchasable.product', 'purchasable.media'])
             ->whereHas(
                 'purchasable',
                 fn (Builder $query) => $query
-                ->whereHas('series')
-                ->orWhereHas('media', fn (Builder $query) => $query->where('collection_name', 'downloads'))
+                    ->whereHas('series')
+                    ->orWhereHas('media', fn (Builder $query) => $query->where('collection_name', 'downloads'))
             )
             ->get()
             ->unique('purchasable_id')
             ->sortBy('purchasable.product.title');
 
-        $applications = $request->user()
+        $applications = $user
             ->assignmentsWithoutRenewals()
-            ->with(['purchasable.product', 'purchasable.media', 'licenses.activations'])
+            ->with(['purchase.user', 'purchasable.product', 'purchasable.media', 'licenses.activations'])
             ->whereHas('licenses')
             ->get()
             ->sortBy('purchasable.product.title')
             ->groupBy('purchasable.product_id');
 
-        return view('front.profile.purchases', compact('courses', 'applications'));
+        $assignedAwayPurchases = $user
+            ->purchasesWithoutRenewals()
+            ->with([
+                'assignments' => fn ($query) => $query
+                    ->where('user_id', '!=', $user->id)
+                    ->with(['purchasable.product', 'user']),
+                'receipt',
+            ])
+            ->whereHas('assignments', fn (Builder $query) => $query->where('user_id', '!=', $user->id))
+            ->get()
+            ->sortByDesc(fn (Purchase $purchase) => $purchase->receipt?->paid_at ?? $purchase->created_at);
+
+        return view('front.profile.purchases', compact('courses', 'applications', 'assignedAwayPurchases'));
     }
 }

--- a/resources/views/front/profile/components/assigned-away-purchase.blade.php
+++ b/resources/views/front/profile/components/assigned-away-purchase.blade.php
@@ -1,0 +1,46 @@
+@php
+    $assignments = $purchase->assignments;
+    $typeLabels = \App\Domain\Shop\Enums\PurchasableType::getLabels();
+    $productTitles = $assignments
+        ->map(fn ($assignment) => $assignment->purchasable->product->title)
+        ->unique()
+        ->join(', ');
+    $purchasableTitles = $assignments
+        ->map(fn ($assignment) => $assignment->purchasable->title)
+        ->unique()
+        ->join(', ');
+    $licenseTypes = $assignments
+        ->map(fn ($assignment) => $typeLabels[$assignment->purchasable->type] ?? $assignment->purchasable->type)
+        ->unique()
+        ->join(', ');
+    $recipientEmails = $assignments
+        ->map(fn ($assignment) => $assignment->user->email)
+        ->unique()
+        ->join(', ');
+    $purchaseDate = $purchase->receipt?->paid_at ?? $purchase->created_at;
+@endphp
+
+<div class="grid gap-4 border border-white/10 bg-white/[0.03] px-4 py-5 text-sm md:grid-cols-[1.2fr_1fr_1fr_auto] md:items-center md:px-6">
+    <div>
+        <div class="font-bold uppercase text-white">{{ $productTitles }}</div>
+        <div class="mt-1 text-xs text-oss-gray-dark">{{ $purchasableTitles }}</div>
+    </div>
+    <div>
+        <div class="text-xs font-bold uppercase tracking-wide text-oss-gray-dark">License</div>
+        <div>{{ $licenseTypes }}</div>
+    </div>
+    <div>
+        <div class="text-xs font-bold uppercase tracking-wide text-oss-gray-dark">Assigned to</div>
+        <div class="break-all">{{ $recipientEmails }}</div>
+        @if($purchaseDate)
+            <div class="mt-1 text-xs text-oss-gray-dark">Bought on {{ $purchaseDate->format('Y-m-d') }}</div>
+        @endif
+    </div>
+    <div>
+        @if($purchase->receipt?->receipt_url)
+            <a class="underline hover:text-white" href="{{ $purchase->receipt->receipt_url }}" target="_blank">Download receipt</a>
+        @else
+            <span class="text-oss-gray-dark">No receipt available</span>
+        @endif
+    </div>
+</div>

--- a/resources/views/front/profile/components/purchase-assignment.blade.php
+++ b/resources/views/front/profile/components/purchase-assignment.blade.php
@@ -13,6 +13,13 @@
             @if($assignment->purchase->created_at)
                 <p class="text-xs text-oss-gray-dark mt-1">Added on {{ $assignment->purchase->created_at->format('Y-m-d') }}</p>
             @endif
+            <div class="mt-3">
+                @if($assignment->purchase->user_id === auth()->id())
+                    <span class="inline-flex rounded-full bg-white/10 px-3 py-1 text-xs font-bold uppercase tracking-wide text-oss-green-pale">Bought by you</span>
+                @else
+                    <span class="inline-flex rounded-full bg-white/10 px-3 py-1 text-xs font-bold uppercase tracking-wide text-oss-gray">Assigned by {{ $assignment->purchase->user->email }}</span>
+                @endif
+            </div>
         </a>
 
         @if ($assignment->purchasable->repository_access)

--- a/resources/views/front/profile/purchases.blade.php
+++ b/resources/views/front/profile/purchases.blade.php
@@ -8,10 +8,12 @@
 
     <x-profile-layout title="Purchases">
         <section class="mb-12">
-            @if (!$courses->count() && !$applications->count())
+            @if(!$courses->count() && !$applications->count() && !$assignedAwayPurchases->count())
                 <p class="text-xl">No purchases yet, take a look at <a class="underline hover:text-white" href="{{ route('products.index') }}">our products</a>.</p>
+            @elseif(!$courses->count() && !$applications->count())
+                <p class="text-xl">Your purchases are assigned to other accounts. You can download receipts below, but product access lives with the assigned recipients.</p>
             @else
-                <p class="text-xl">Here you'll find all your purchased applications and courses.</p>
+                <p class="text-xl">Here you'll find products assigned to your account and purchases you bought for others.</p>
             @endif
         </section>
 
@@ -148,6 +150,16 @@
                                         @endforeach
                                     </div>
                                 </x-purchase-assignment>
+                            @endforeach
+                        </div>
+                    @endif
+
+                    @if(count($assignedAwayPurchases))
+                        <h2 class="font-druk uppercase text-[40px] leading-[0.9] mt-16 mb-4">Assigned to others</h2>
+                        <p class="mb-8 text-sm text-oss-gray-dark">These purchases were paid for by you, but access was assigned to another account.</p>
+                        <div class="grid gap-4">
+                            @foreach($assignedAwayPurchases as $purchase)
+                                @include('front.profile.components.assigned-away-purchase', ['purchase' => $purchase])
                             @endforeach
                         </div>
                     @endif

--- a/tests/Http/Controllers/PurchasesControllerTest.php
+++ b/tests/Http/Controllers/PurchasesControllerTest.php
@@ -1,0 +1,149 @@
+<?php
+
+use App\Domain\Shop\Enums\PurchasableType;
+use App\Domain\Shop\Models\License;
+use App\Domain\Shop\Models\Product;
+use App\Domain\Shop\Models\Purchasable;
+use App\Domain\Shop\Models\Purchase;
+use App\Domain\Shop\Models\PurchaseAssignment;
+use App\Models\Series;
+use App\Models\User;
+use Database\Factories\ReceiptFactory;
+use Illuminate\Support\Str;
+
+function createPurchasesPagePurchasable(
+    string $productTitle,
+    string $purchasableTitle,
+    string $type = PurchasableType::TYPE_UNLIMITED_DOMAINS,
+): Purchasable {
+    $product = Product::factory()->create([
+        'title' => $productTitle,
+        'slug' => Str::slug($productTitle),
+        'maximum_activation_count' => 1,
+    ]);
+
+    return Purchasable::factory()->create([
+        'product_id' => $product->id,
+        'title' => $purchasableTitle,
+        'type' => $type,
+    ]);
+}
+
+function createPurchasesPagePurchase(User $buyer, Purchasable $purchasable, string $receiptUrl = 'https://example.com/receipt'): Purchase
+{
+    $receipt = ReceiptFactory::new()
+        ->for($buyer, 'billable')
+        ->create(['receipt_url' => $receiptUrl]);
+
+    return Purchase::factory()->create([
+        'user_id' => $buyer->id,
+        'purchasable_id' => $purchasable->id,
+        'receipt_id' => $receipt->id,
+    ]);
+}
+
+function assignPurchasesPagePurchase(Purchase $purchase, Purchasable $purchasable, User $user): PurchaseAssignment
+{
+    return PurchaseAssignment::factory()->create([
+        'purchase_id' => $purchase->id,
+        'purchasable_id' => $purchasable->id,
+        'user_id' => $user->id,
+    ]);
+}
+
+it('shows a self-assigned application as usable access only', function () {
+    $user = User::factory()->create();
+    $purchasable = createPurchasesPagePurchasable('Ray', 'Ray license');
+    $purchase = createPurchasesPagePurchase($user, $purchasable);
+    $assignment = assignPurchasesPagePurchase($purchase, $purchasable, $user);
+    License::factory()->create(['purchase_assignment_id' => $assignment->id]);
+
+    $this
+        ->actingAs($user)
+        ->get(route('purchases'))
+        ->assertOk()
+        ->assertSee('Applications')
+        ->assertSee('Ray')
+        ->assertSee('Bought by you')
+        ->assertDontSee('Assigned to others');
+});
+
+it('shows externally bought access assigned to the user with purchaser context', function () {
+    $user = User::factory()->create();
+    $buyer = User::factory()->create(['email' => 'external-buyer@example.com']);
+    $purchasable = createPurchasesPagePurchasable('Mailcoach', 'Only the videos', PurchasableType::TYPE_VIDEOS);
+    $series = Series::factory()->create(['title' => 'Mailcoach videos']);
+    $purchasable->series()->attach($series);
+    $purchase = createPurchasesPagePurchase($buyer, $purchasable);
+    assignPurchasesPagePurchase($purchase, $purchasable, $user);
+
+    $this
+        ->actingAs($user)
+        ->get(route('purchases'))
+        ->assertOk()
+        ->assertSee('Courses')
+        ->assertSee('Mailcoach')
+        ->assertSee('Assigned by external-buyer@example.com')
+        ->assertDontSee('Assigned to others');
+});
+
+it('shows user-owned purchases assigned to another user separately from usable access', function () {
+    $user = User::factory()->create();
+    $recipient = User::factory()->create(['email' => 'recipient@example.com']);
+    $purchasable = createPurchasesPagePurchasable('Mailcoach', 'Single domain');
+    $purchase = createPurchasesPagePurchase($user, $purchasable, 'https://example.com/mailcoach-receipt');
+    assignPurchasesPagePurchase($purchase, $purchasable, $recipient);
+
+    $this
+        ->actingAs($user)
+        ->get(route('purchases'))
+        ->assertOk()
+        ->assertDontSee('Applications')
+        ->assertSee('Assigned to others')
+        ->assertSee('Mailcoach')
+        ->assertSee('Single domain')
+        ->assertSee('recipient@example.com')
+        ->assertSee('Download receipt');
+});
+
+it('shows mixed multi-seat purchases as usable access and lists the other recipient', function () {
+    $user = User::factory()->create(['email' => 'buyer@example.com']);
+    $recipient = User::factory()->create(['email' => 'recipient@example.com']);
+    $purchasable = createPurchasesPagePurchasable('Mailcoach', 'Unlimited domains');
+    $purchase = createPurchasesPagePurchase($user, $purchasable);
+    $userAssignment = assignPurchasesPagePurchase($purchase, $purchasable, $user);
+    assignPurchasesPagePurchase($purchase, $purchasable, $recipient);
+    License::factory()->create(['purchase_assignment_id' => $userAssignment->id]);
+
+    $this
+        ->actingAs($user)
+        ->get(route('purchases'))
+        ->assertOk()
+        ->assertSee('Applications')
+        ->assertSee('Bought by you')
+        ->assertSee('Assigned to others')
+        ->assertSee('recipient@example.com');
+});
+
+it('distinguishes between no purchases and purchases that are only assigned away', function () {
+    $user = User::factory()->create();
+
+    $this
+        ->actingAs($user)
+        ->get(route('purchases'))
+        ->assertOk()
+        ->assertSee('No purchases yet');
+
+    $recipient = User::factory()->create(['email' => 'recipient@example.com']);
+    $purchasable = createPurchasesPagePurchasable('Mailcoach', 'Single domain');
+    $purchase = createPurchasesPagePurchase($user, $purchasable);
+    assignPurchasesPagePurchase($purchase, $purchasable, $recipient);
+
+    $this
+        ->actingAs($user)
+        ->get(route('purchases'))
+        ->assertOk()
+        ->assertDontSee('No purchases yet')
+        ->assertSee('Your purchases are assigned to other accounts')
+        ->assertSee('Assigned to others');
+});


### PR DESCRIPTION
## Summary
- separate usable assigned products from buyer-owned purchases assigned to other accounts
- add ownership/assignment badges to purchase cards
- add an Assigned to others section with recipient and receipt details
- add focused feature coverage for self-assigned, externally assigned, assigned-away, mixed-seat, and empty states

## Tests
- php -l app/Http/Controllers/PurchasesController.php
- php -l tests/Http/Controllers/PurchasesControllerTest.php
- ./vendor/bin/pest --compact tests/Http/Controllers/PurchasesControllerTest.php
- ./vendor/bin/pest --compact tests/Http/Controllers

## Manual verification
- logged in locally as purchases-demo@spatie.be
- verified Ray appears under Applications
- verified Mailcoach videos appear under Courses
- verified Mailcoach purchases assigned to another account appear under Assigned to others
- verified /profile/invoices still shows buyer-owned receipts