### PR TITLE
Sync GitHub releases and tags for packages

### DIFF
--- a/app/Actions/ImportRepositoryReleasesAction.php
+++ b/app/Actions/ImportRepositoryReleasesAction.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\Repository;
+use App\Services\GitHub\GitHubApi;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+
+class ImportRepositoryReleasesAction
+{
+    public function __construct(private readonly GitHubApi $gitHubApi)
+    {
+    }
+
+    public function execute(Repository $repository): void
+    {
+        $tagShas = $this->gitHubApi
+            ->fetchTags($repository->full_name)
+            ->mapWithKeys(fn (array $tag) => [$tag['name'] => $tag['commit']['sha']]);
+
+        $this->importReleases($repository, $tagShas);
+
+        $this->importTags($repository, $tagShas);
+    }
+
+    /** @param Collection<string, string> $tagShas */
+    private function importReleases(Repository $repository, Collection $tagShas): void
+    {
+        $this->gitHubApi
+            ->fetchReleases($repository->full_name)
+            ->reject(fn (array $release) => $release['draft'] ?? false)
+            ->each(function (array $release) use ($repository, $tagShas): void {
+                $repository->releases()->updateOrCreate(['tag_name' => $release['tag_name']], [
+                    'name' => $release['name'] ?? null,
+                    'body' => $release['body'] ?? null,
+                    'url' => $release['html_url'],
+                    'commit_sha' => $tagShas->get($release['tag_name']),
+                    'is_release' => true,
+                    'is_prerelease' => $release['prerelease'] ?? false,
+                    'released_at' => Carbon::make($release['published_at'] ?? null),
+                ]);
+            });
+    }
+
+    /** @param Collection<string, string> $tagShas */
+    private function importTags(Repository $repository, Collection $tagShas): void
+    {
+        $existingTagNames = $repository->releases()->pluck('tag_name')->all();
+
+        $tagShas
+            ->reject(fn (string $sha, string $tagName) => in_array($tagName, $existingTagNames, true))
+            ->each(function (string $sha, string $tagName) use ($repository): void {
+                $repository->releases()->create([
+                    'tag_name' => $tagName,
+                    'commit_sha' => $sha,
+                    'url' => "https://github.com/{$repository->full_name}/releases/tag/{$tagName}",
+                    'is_release' => false,
+                    'is_prerelease' => false,
+                    'released_at' => $this->gitHubApi->fetchCommitDate($repository->full_name, $sha),
+                ]);
+            });
+    }
+}

--- a/app/Console/Commands/ImportGitHubReleasesCommand.php
+++ b/app/Console/Commands/ImportGitHubReleasesCommand.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Actions\ImportRepositoryReleasesAction;
+use App\Models\Repository;
+use Illuminate\Console\Command;
+use Throwable;
+
+class ImportGitHubReleasesCommand extends Command
+{
+    protected $signature = 'import:github-releases';
+
+    protected $description = 'Import releases and tags for all package repositories';
+
+    public function handle(ImportRepositoryReleasesAction $importRepositoryReleasesAction): void
+    {
+        $repositories = Repository::packages()->get();
+
+        $repositories->each(function (Repository $repository) use ($importRepositoryReleasesAction): void {
+            $this->info("Importing releases for `{$repository->name}`...");
+
+            try {
+                $importRepositoryReleasesAction->execute($repository);
+            } catch (Throwable $exception) {
+                report($exception);
+
+                $this->error("Failed to import releases for `{$repository->name}`: {$exception->getMessage()}");
+            }
+        });
+
+        $this->comment("Imported releases for {$repositories->count()} packages.");
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -5,6 +5,7 @@ namespace App\Console;
 use App\Console\Commands\AfterworkCommand;
 use App\Console\Commands\ImportAllDocsCommand;
 use App\Console\Commands\ImportDocsFromRepositoriesCommand;
+use App\Console\Commands\ImportGitHubReleasesCommand;
 use App\Console\Commands\ImportGitHubRepositoriesCommand;
 use App\Console\Commands\ImportGuideLinesCommand;
 use App\Console\Commands\ImportInsightsCommand;
@@ -30,6 +31,7 @@ class Kernel extends ConsoleKernel
         $schedule->command(ImportInsightsCommand::class)->hourly();
         $schedule->command(ImportPackagistDownloadsCommand::class)->hourly();
         $schedule->command(ImportGitHubRepositoriesCommand::class)->weekly();
+        $schedule->command(ImportGitHubReleasesCommand::class)->runInBackground()->withoutOverlapping()->dailyAt('02:30');
         $schedule->command(ImportGuideLinesCommand::class)->weekly();
         $schedule->command(RegenerateLeakedKeysCommand::class)->graceTimeInMinutes(30)->runInBackground()->hourly();
 

--- a/app/Filament/Resources/Content/RepositoryReleaseResource.php
+++ b/app/Filament/Resources/Content/RepositoryReleaseResource.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Filament\Resources\Content;
+
+use App\Filament\Resources\Content\RepositoryReleaseResource\Pages\ListRepositoryReleases;
+use App\Filament\Tables\Columns\BooleanColumn;
+use App\Models\RepositoryRelease;
+use Filament\Resources\Resource;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class RepositoryReleaseResource extends Resource
+{
+    protected static ?string $model = RepositoryRelease::class;
+
+    protected static string | \UnitEnum | null $navigationGroup = 'Content';
+
+    protected static ?int $navigationSort = 4;
+
+    protected static string | \BackedEnum | null $navigationIcon = 'heroicon-o-tag';
+
+    protected static ?string $recordTitleAttribute = 'tag_name';
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->defaultSort('released_at', 'desc')
+            ->columns([
+                TextColumn::make('repository.name')
+                    ->label('Package')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('tag_name')
+                    ->label('Version')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('name')
+                    ->label('Title')
+                    ->limit(50)
+                    ->toggleable(),
+                BooleanColumn::make('is_release')
+                    ->label('Release'),
+                BooleanColumn::make('is_prerelease')
+                    ->label('Pre-release')
+                    ->toggleable(),
+                TextColumn::make('released_at')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->recordUrl(fn (RepositoryRelease $record) => $record->url)
+            ->openRecordUrlInNewTab();
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListRepositoryReleases::route('/'),
+        ];
+    }
+}

--- a/app/Filament/Resources/Content/RepositoryReleaseResource/Pages/ListRepositoryReleases.php
+++ b/app/Filament/Resources/Content/RepositoryReleaseResource/Pages/ListRepositoryReleases.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\Content\RepositoryReleaseResource\Pages;
+
+use App\Filament\Resources\Content\RepositoryReleaseResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListRepositoryReleases extends ListRecords
+{
+    protected static string $resource = RepositoryReleaseResource::class;
+}

--- a/app/Models/Repository.php
+++ b/app/Models/Repository.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Spatie\MediaLibrary\HasMedia;
@@ -56,6 +57,12 @@ class Repository extends Model implements HasMedia
     public function ad(): BelongsTo
     {
         return $this->belongsTo(Ad::class, 'ad_id');
+    }
+
+    /** @return HasMany<RepositoryRelease, $this> */
+    public function releases(): HasMany
+    {
+        return $this->hasMany(RepositoryRelease::class);
     }
 
     public function getSlug(): string

--- a/app/Models/RepositoryRelease.php
+++ b/app/Models/RepositoryRelease.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class RepositoryRelease extends Model
+{
+    use HasFactory;
+
+    protected $casts = [
+        'is_release' => 'boolean',
+        'is_prerelease' => 'boolean',
+        'released_at' => 'datetime',
+    ];
+
+    /** @return BelongsTo<Repository, $this> */
+    public function repository(): BelongsTo
+    {
+        return $this->belongsTo(Repository::class);
+    }
+}

--- a/app/Services/GitHub/GitHubApi.php
+++ b/app/Services/GitHub/GitHubApi.php
@@ -36,6 +36,42 @@ class GitHubApi
         });
     }
 
+    public function fetchReleases(string $repository): Collection
+    {
+        [$organisation, $repository] = explode('/', $repository);
+
+        /** @var Repo $repoApi */
+        $repoApi = $this->client->api('repo');
+
+        $paginator = new ResultPager($this->client, 100);
+
+        return collect($paginator->fetchAll($repoApi->releases(), 'all', [$organisation, $repository]));
+    }
+
+    public function fetchTags(string $repository): Collection
+    {
+        [$organisation, $repository] = explode('/', $repository);
+
+        /** @var Repo $repoApi */
+        $repoApi = $this->client->api('repo');
+
+        $paginator = new ResultPager($this->client, 100);
+
+        return collect($paginator->fetchAll($repoApi, 'tags', [$organisation, $repository]));
+    }
+
+    public function fetchCommitDate(string $repository, string $sha): Carbon
+    {
+        [$organisation, $repository] = explode('/', $repository);
+
+        /** @var Repo $repoApi */
+        $repoApi = $this->client->api('repo');
+
+        $commit = $repoApi->commits()->show($organisation, $repository, $sha);
+
+        return Carbon::parse($commit['commit']['committer']['date']);
+    }
+
     public function latestVersionOnDate(string $repository, Carbon $onDate): string
     {
         [$organisation, $repository] = explode('/', $repository);

--- a/database/factories/RepositoryReleaseFactory.php
+++ b/database/factories/RepositoryReleaseFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Repository;
+use App\Models\RepositoryRelease;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<RepositoryRelease> */
+class RepositoryReleaseFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'repository_id' => Repository::factory(),
+            'tag_name' => $this->faker->numerify('#.#.#'),
+            'name' => $this->faker->sentence(),
+            'body' => $this->faker->paragraph(),
+            'url' => $this->faker->url(),
+            'commit_sha' => $this->faker->sha1(),
+            'is_release' => true,
+            'is_prerelease' => false,
+            'released_at' => $this->faker->dateTimeThisYear(),
+        ];
+    }
+}

--- a/database/migrations/2026_06_18_120000_create_repository_releases_table.php
+++ b/database/migrations/2026_06_18_120000_create_repository_releases_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('repository_releases', function (Blueprint $table) {
+            $table->id();
+            // repositories.id is int unsigned, so the foreign key column must match it (not bigint)
+            $table->unsignedInteger('repository_id');
+            $table->foreign('repository_id')->references('id')->on('repositories')->cascadeOnDelete();
+            $table->string('tag_name');
+            $table->string('name')->nullable();
+            $table->longText('body')->nullable();
+            $table->string('url')->nullable();
+            $table->string('commit_sha')->nullable();
+            $table->boolean('is_release')->default(false);
+            $table->boolean('is_prerelease')->default(false);
+            $table->dateTime('released_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['repository_id', 'tag_name']);
+            $table->index('released_at');
+        });
+    }
+};

--- a/docs/superpowers/specs/2026-06-18-oss-releases-sync-design.md
+++ b/docs/superpowers/specs/2026-06-18-oss-releases-sync-design.md
@@ -1,0 +1,65 @@
+# OSS package releases sync
+
+## Goal
+
+Pull GitHub releases and git tags for all Spatie **packages** into a new structured table, refreshed daily and incrementally via a scheduled command. Add a read-only internal view in the Filament admin panel so the team can see what shipped recently.
+
+Out of scope for now: a public, curated website feed (a future step).
+
+## Scope decisions
+
+- **Deliverable:** data sync (DB + cron) + a read-only Filament admin view.
+- **Captured data:** both GitHub releases and git tags. A release where available (rich notes), otherwise a tag-only entry.
+- **Repositories:** only `package` type rows from the existing `repositories` table (`Repository::packages()`).
+- **Frequency:** daily, incremental.
+
+## Data model
+
+New table `repository_releases`, model `App\Models\RepositoryRelease`. One row per tag per package.
+
+| Column | Purpose |
+|---|---|
+| `id` | PK |
+| `repository_id` | FK → `repositories`, cascade on delete |
+| `tag_name` | e.g. `10.0.1` or `v2.3.0` (raw tag) |
+| `name` | release title (null for tag-only) |
+| `body` | release notes / changelog markdown (null for tag-only) |
+| `url` | html URL of the release, or the tag's GitHub URL |
+| `commit_sha` | the tag/release target commit |
+| `is_release` | bool, true if a GitHub Release exists, false if tag-only |
+| `is_prerelease` | bool |
+| `released_at` | release `published_at`, or the tag commit date for tag-only |
+| `created_at` / `updated_at` | timestamps |
+
+- Unique index on `(repository_id, tag_name)`.
+- Index on `released_at` for "recent" ordering.
+- `Repository hasMany RepositoryRelease`; `RepositoryRelease belongsTo Repository`.
+
+## Fetching
+
+Extend `App\Services\GitHub\GitHubApi` (knplabs/github-api) with pure API methods returning raw arrays:
+
+- `fetchReleases(string $repository): Collection` — all releases (paginated).
+- `fetchTags(string $repository): Collection` — all tags (paginated).
+- `fetchCommitDate(string $repository, string $sha): Carbon` — committer date for a tag's commit (only needed to date tag-only entries).
+
+## Sync logic
+
+`App\Actions\ImportRepositoryReleasesAction::execute(Repository $repository): void`
+
+1. Fetch releases. Skip drafts. For each, `updateOrCreate` keyed on `(repository_id, tag_name)` with `is_release = true`, `name`, `body`, `url`, `is_prerelease`, `released_at = published_at`, `commit_sha`.
+2. Fetch tags. For any tag whose row does not already exist (after step 1), create a tag-only row (`is_release = false`), using `fetchCommitDate` for `released_at`.
+
+Incrementality: releases use idempotent `updateOrCreate`; commit-date lookups only happen for genuinely new tag-only versions, so steady-state daily runs do no extra per-tag work and no writes when nothing changed.
+
+## Command & schedule
+
+`App\Console\Commands\ImportGitHubReleasesCommand` (`import:github-releases`): iterate `Repository::packages()->get()`, call the action per package with progress output. Schedule `dailyAt` in `app/Console/Kernel.php`.
+
+## Internal view
+
+Read-only `RepositoryReleaseResource` (Filament, "Content" group). Index page only, no create/edit/delete. Columns: repository name, tag, title, is_release, is_prerelease, released_at. Default sort `released_at` desc. Searchable on tag and repository name.
+
+## Testing
+
+Pest tests for the action (releases imported, tag-only imported with commit date, drafts skipped, idempotent re-run) and the command (runs for packages only), using a mocked `GitHubApi`.

--- a/tests/Actions/ImportRepositoryReleasesActionTest.php
+++ b/tests/Actions/ImportRepositoryReleasesActionTest.php
@@ -1,0 +1,135 @@
+<?php
+
+use App\Actions\ImportRepositoryReleasesAction;
+use App\Models\Repository;
+use App\Models\RepositoryRelease;
+use App\Services\GitHub\GitHubApi;
+use Illuminate\Support\Carbon;
+
+beforeEach(function () {
+    $this->api = $this->mock(GitHubApi::class);
+    $this->action = resolve(ImportRepositoryReleasesAction::class);
+
+    $this->repository = Repository::factory()->create(['name' => 'laravel-backup']);
+});
+
+it('imports github releases for a repository', function () {
+    $this->api->shouldReceive('fetchReleases')->with('spatie/laravel-backup')->andReturn(collect([
+        [
+            'tag_name' => '10.0.1',
+            'name' => 'Fix a bug',
+            'body' => '## What changed',
+            'html_url' => 'https://github.com/spatie/laravel-backup/releases/tag/10.0.1',
+            'prerelease' => false,
+            'draft' => false,
+            'published_at' => '2026-06-10T08:00:00Z',
+            'target_commitish' => 'main',
+        ],
+    ]));
+    $this->api->shouldReceive('fetchTags')->andReturn(collect([
+        ['name' => '10.0.1', 'commit' => ['sha' => 'abc123']],
+    ]));
+
+    $this->action->execute($this->repository);
+
+    expect($this->repository->releases)->toHaveCount(1);
+
+    tap($this->repository->releases->first(), function (RepositoryRelease $release) {
+        expect($release->tag_name)->toBe('10.0.1');
+        expect($release->name)->toBe('Fix a bug');
+        expect($release->body)->toBe('## What changed');
+        expect($release->url)->toBe('https://github.com/spatie/laravel-backup/releases/tag/10.0.1');
+        expect($release->is_release)->toBeTrue();
+        expect($release->is_prerelease)->toBeFalse();
+        expect($release->commit_sha)->toBe('abc123');
+        expect($release->released_at->toDateTimeString())->toBe('2026-06-10 08:00:00');
+    });
+});
+
+it('imports a tag without a release using the commit date', function () {
+    $this->api->shouldReceive('fetchReleases')->andReturn(collect());
+    $this->api->shouldReceive('fetchTags')->with('spatie/laravel-backup')->andReturn(collect([
+        ['name' => '1.0.0', 'commit' => ['sha' => 'def456']],
+    ]));
+    $this->api->shouldReceive('fetchCommitDate')
+        ->with('spatie/laravel-backup', 'def456')
+        ->andReturn(Carbon::parse('2018-01-01 12:00:00'));
+
+    $this->action->execute($this->repository);
+
+    tap($this->repository->releases->first(), function (RepositoryRelease $release) {
+        expect($release->tag_name)->toBe('1.0.0');
+        expect($release->is_release)->toBeFalse();
+        expect($release->name)->toBeNull();
+        expect($release->commit_sha)->toBe('def456');
+        expect($release->released_at->toDateTimeString())->toBe('2018-01-01 12:00:00');
+    });
+});
+
+it('skips draft releases', function () {
+    $this->api->shouldReceive('fetchReleases')->andReturn(collect([
+        [
+            'tag_name' => '10.0.2',
+            'name' => 'Unreleased',
+            'body' => '',
+            'html_url' => 'https://github.com/spatie/laravel-backup/releases/tag/10.0.2',
+            'prerelease' => false,
+            'draft' => true,
+            'published_at' => null,
+            'target_commitish' => 'main',
+        ],
+    ]));
+    $this->api->shouldReceive('fetchTags')->andReturn(collect());
+
+    $this->action->execute($this->repository);
+
+    expect($this->repository->releases)->toHaveCount(0);
+});
+
+it('does not create a tag-only row when a release already covers the tag', function () {
+    $this->api->shouldReceive('fetchReleases')->andReturn(collect([
+        [
+            'tag_name' => '10.0.1',
+            'name' => 'Fix a bug',
+            'body' => 'notes',
+            'html_url' => 'https://github.com/spatie/laravel-backup/releases/tag/10.0.1',
+            'prerelease' => false,
+            'draft' => false,
+            'published_at' => '2026-06-10T08:00:00Z',
+            'target_commitish' => 'main',
+        ],
+    ]));
+    $this->api->shouldReceive('fetchTags')->andReturn(collect([
+        ['name' => '10.0.1', 'commit' => ['sha' => 'abc123']],
+    ]));
+    $this->api->shouldNotReceive('fetchCommitDate');
+
+    $this->action->execute($this->repository);
+
+    expect($this->repository->releases)->toHaveCount(1);
+});
+
+it('is idempotent when run twice', function () {
+    $releases = collect([
+        [
+            'tag_name' => '10.0.1',
+            'name' => 'Fix a bug',
+            'body' => 'notes',
+            'html_url' => 'https://github.com/spatie/laravel-backup/releases/tag/10.0.1',
+            'prerelease' => false,
+            'draft' => false,
+            'published_at' => '2026-06-10T08:00:00Z',
+            'target_commitish' => 'main',
+        ],
+    ]);
+
+    $this->api->shouldReceive('fetchReleases')->andReturn($releases);
+    $this->api->shouldReceive('fetchTags')->andReturn(collect([
+        ['name' => '10.0.1', 'commit' => ['sha' => 'abc123']],
+    ]));
+
+    $this->action->execute($this->repository);
+    $this->action->execute($this->repository);
+
+    expect(RepositoryRelease::where('repository_id', $this->repository->id)->count())->toBe(1);
+});

--- a/tests/Console/Commands/ImportGitHubReleasesCommandTest.php
+++ b/tests/Console/Commands/ImportGitHubReleasesCommandTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Actions\ImportRepositoryReleasesAction;
+use App\Console\Commands\ImportGitHubReleasesCommand;
+use App\Models\Enums\RepositoryType;
+use App\Models\Repository;
+
+beforeEach(function () {
+    $this->actionSpy = $this->spy(ImportRepositoryReleasesAction::class);
+});
+
+it('imports releases for every package repository', function () {
+    $package = Repository::factory()->create(['type' => RepositoryType::PACKAGE]);
+
+    $this->artisan(ImportGitHubReleasesCommand::class)->assertSuccessful();
+
+    $this->actionSpy->shouldHaveReceived('execute')
+        ->withArgs(fn (Repository $repository) => $repository->is($package))
+        ->once();
+});
+
+it('does not import releases for project repositories', function () {
+    Repository::factory()->create(['type' => RepositoryType::PROJECT]);
+
+    $this->artisan(ImportGitHubReleasesCommand::class)->assertSuccessful();
+
+    $this->actionSpy->shouldNotHaveReceived('execute');
+});

--- a/tests/Feature/Filament/RepositoryReleaseResourceTest.php
+++ b/tests/Feature/Filament/RepositoryReleaseResourceTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use App\Models\RepositoryRelease;
+
+it('shows the releases index page to admins', function () {
+    $this->actingAsSpatie();
+
+    RepositoryRelease::factory()->create();
+
+    $this->get(route('filament.admin.resources.content.repository-releases.index'))
+        ->assertSuccessful();
+});
+
+it('does not expose a create page', function () {
+    $this->actingAsSpatie();
+
+    expect(fn () => route('filament.admin.resources.content.repository-releases.create'))
+        ->toThrow(Symfony\Component\Routing\Exception\RouteNotFoundException::class);
+});


### PR DESCRIPTION
Pulls GitHub releases and git tags for every package repository into a new `repository_releases` table, refreshed daily and incrementally via the `import:github-releases` command (scheduled `dailyAt('02:30')`, `withoutOverlapping`). Each version stores its notes, title, prerelease flag, published date and commit SHA; versions that only have a git tag (no GitHub release) are captured too, dated from the tag's commit.

Adds a read-only admin view under Content → Repository Releases to see what recently shipped.

From Seb's request: have all package tags/releases as structured data to play with internally. A curated public website feed is intentionally left out for now.