### PR TITLE
Add Bing Webmaster Tools verification meta tag

### DIFF
--- a/resources/views/layout/partials/meta.blade.php
+++ b/resources/views/layout/partials/meta.blade.php
@@ -2,6 +2,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover">
 <meta name="color-scheme" content="dark light">
 <meta name="theme-color" content="#050508">
+<meta name="msvalidate.01" content="66E6FAFC3E214E528EECBD04ECA4804C" />
 
 <link rel="dns-prefetch" href="https://cloud.typography.com">
 <link rel="dns-prefetch" href="https://pro.fontawesome.com">


### PR DESCRIPTION
Adds the `msvalidate.01` meta tag to the site head partial so Bing Webmaster Tools can verify ownership of spatie.be. It renders on every page alongside the other meta tags.