### PR TITLE
Fix broken /docs links in package documentation

### DIFF
--- a/app/Http/Controllers/DocsController.php
+++ b/app/Http/Controllers/DocsController.php
@@ -8,6 +8,7 @@ use App\Docs\DocumentationPage;
 use App\Docs\Highlighting\DiffLanguage;
 use App\Docs\Highlighting\JsxLanguage;
 use App\Models\Repository;
+use App\Support\CommonMark\DocsLinkPrefixExtension;
 use App\Support\CommonMark\ImageRenderer;
 use App\Support\CommonMark\LinkRenderer;
 use Illuminate\Support\Arr;
@@ -204,6 +205,7 @@ class DocsController
             ->highlightCode(false)
             ->addExtension(new TableExtension())
             ->addExtension(new HeadingPermalinkExtension())
+            ->addExtension(new DocsLinkPrefixExtension())
             ->addExtension(new WireNavigateExtension())
             ->addInlineRenderer(Image::class, new ImageRenderer())
             ->addInlineRenderer(Link::class, new LinkRenderer())

--- a/app/Support/CommonMark/DocsLinkPrefixExtension.php
+++ b/app/Support/CommonMark/DocsLinkPrefixExtension.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Support\CommonMark;
+
+use Illuminate\Support\Str;
+use League\CommonMark\Environment\EnvironmentBuilderInterface;
+use League\CommonMark\Event\DocumentParsedEvent;
+use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
+use League\CommonMark\Extension\ExtensionInterface;
+
+class DocsLinkPrefixExtension implements ExtensionInterface
+{
+    public function register(EnvironmentBuilderInterface $environment): void
+    {
+        $environment->addEventListener(DocumentParsedEvent::class, function (DocumentParsedEvent $event): void {
+            foreach ($event->getDocument()->iterator() as $node) {
+                if (! $node instanceof Link) {
+                    continue;
+                }
+
+                if (! Str::startsWith($node->getUrl(), '/')) {
+                    continue;
+                }
+
+                $node->setUrl(Str::start($node->getUrl(), '/docs'));
+            }
+        });
+    }
+}

--- a/tests/Support/CommonMark/DocsLinkPrefixExtensionTest.php
+++ b/tests/Support/CommonMark/DocsLinkPrefixExtensionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Support\CommonMark;
+
+use App\Support\CommonMark\DocsLinkPrefixExtension;
+use App\Support\CommonMark\LinkRenderer;
+use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
+use Spatie\CommonMarkWireNavigate\WireNavigateExtension;
+use Spatie\LaravelMarkdown\MarkdownRenderer;
+
+function renderDocsMarkdown(string $markdown): string
+{
+    return app(MarkdownRenderer::class)
+        ->highlightCode(false)
+        ->addExtension(new DocsLinkPrefixExtension())
+        ->addExtension(new WireNavigateExtension())
+        ->addInlineRenderer(Link::class, new LinkRenderer())
+        ->commonmarkOptions([
+            'wire_navigate' => ['paths' => ['docs']],
+        ])
+        ->toHtml($markdown);
+}
+
+it('prefixes root-relative links with /docs', function () {
+    $html = renderDocsMarkdown('[fluent methods](/laravel-html/general-usage/element-methods)');
+
+    expect($html)->toContain('href="/docs/laravel-html/general-usage/element-methods"');
+});
+
+it('marks prefixed docs links for wire:navigate', function () {
+    $html = renderDocsMarkdown('[fluent methods](/laravel-html/general-usage/element-methods)');
+
+    expect($html)->toContain('wire:navigate');
+});
+
+it('does not double prefix links that already start with /docs', function () {
+    $html = renderDocsMarkdown('[comments](/docs/laravel-comments/v2/basic-usage/transforming-comments)');
+
+    expect($html)
+        ->toContain('href="/docs/laravel-comments/v2/basic-usage/transforming-comments"')
+        ->not->toContain('/docs/docs/');
+});
+
+it('leaves absolute urls untouched', function () {
+    $html = renderDocsMarkdown('[newsletter](https://spatie.be/newsletter)');
+
+    expect($html)
+        ->toContain('href="https://spatie.be/newsletter"')
+        ->not->toContain('/docs/');
+});


### PR DESCRIPTION
Root-relative markdown links in package docs lost their `/docs` prefix (and `wire:navigate`) after the CommonMark v2 migration, because `WireNavigateExtension` overrides the custom `LinkRenderer`. This adds a `DocsLinkPrefixExtension` that rewrites those links in the AST before rendering, fixing the 404s and restoring SPA navigation across all packages and versions at once. Covers the bulk of the reported dead links; the few remaining content errors (a typo and dead placeholder targets) are fixed in separate package-repo PRs (spatie/laravel-comments#235, spatie/laravel-event-sourcing#531).