### PR TITLE
Fix TypeError when highlighting diff code blocks

### DIFF
--- a/app/Docs/Highlighting/DiffAdditionInjection.php
+++ b/app/Docs/Highlighting/DiffAdditionInjection.php
@@ -4,9 +4,10 @@ namespace App\Docs\Highlighting;
 
 use Tempest\Highlight\Escape;
 use Tempest\Highlight\Highlighter;
+use Tempest\Highlight\Injection;
 use Tempest\Highlight\ParsedInjection;
 
-class DiffAdditionInjection
+class DiffAdditionInjection implements Injection
 {
     public function parse(string $content, Highlighter $highlighter): ParsedInjection
     {

--- a/app/Docs/Highlighting/DiffDeletionInjection.php
+++ b/app/Docs/Highlighting/DiffDeletionInjection.php
@@ -4,9 +4,10 @@ namespace App\Docs\Highlighting;
 
 use Tempest\Highlight\Escape;
 use Tempest\Highlight\Highlighter;
+use Tempest\Highlight\Injection;
 use Tempest\Highlight\ParsedInjection;
 
-class DiffDeletionInjection
+class DiffDeletionInjection implements Injection
 {
     public function parse(string $content, Highlighter $highlighter): ParsedInjection
     {

--- a/tests/Docs/Highlighting/DiffLanguageTest.php
+++ b/tests/Docs/Highlighting/DiffLanguageTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Docs\Highlighting;
+
+use App\Docs\Highlighting\DiffLanguage;
+use Tempest\Highlight\Highlighter;
+
+it('highlights diff code blocks without throwing', function () {
+    $highlighter = new Highlighter();
+    $highlighter->addLanguage(new DiffLanguage());
+
+    $html = $highlighter->parse("+ added line\n- removed line", 'diff');
+
+    expect($html)
+        ->toContain('hl-addition')
+        ->toContain('hl-deletion');
+});


### PR DESCRIPTION
`tempest/highlight`'s `Highlighter::isAfterInjection()` type-hints the `Injection` interface, but `DiffAdditionInjection`/`DiffDeletionInjection` only duck-typed `parse()` without implementing it, throwing a `TypeError` whenever a diff code block is rendered fresh (449 occurrences in Flare, all on `DocsController@show`). They now implement the interface. The bug was masked by the rendered-markdown cache and surfaced after a cache clear.