### PR TITLE
Add self-referencing canonical to every page

### DIFF
--- a/resources/views/layout/partials/meta.blade.php
+++ b/resources/views/layout/partials/meta.blade.php
@@ -15,9 +15,7 @@
 <meta property="og:url" content="{{ request()->getUri() }}"/>
 <meta property="og:type" content="website" />
 
-@if (isset($canonical) && $canonical)
-    <link rel="canonical" href="{{ $canonical }}" />
-@endif
+<link rel="canonical" href="{{ $canonical ?? request()->url() }}" />
 
 @if (isset($noIndex) && $noIndex)
     <meta name="robots" content="noindex">

--- a/tests/Feature/Pages/CanonicalTest.php
+++ b/tests/Feature/Pages/CanonicalTest.php
@@ -1,0 +1,7 @@
+<?php
+
+it('renders a self-referencing canonical with the clean url', function () {
+    $this->get('/?utm_source=newsletter')
+        ->assertStatus(200)
+        ->assertSee('<link rel="canonical" href="'.url('/').'" />', false);
+});


### PR DESCRIPTION
Renders a `<link rel="canonical">` on every page, falling back to the current clean URL (`request()->url()`, which strips the query string) when a page does not set an explicit canonical. Pages that already pass `$canonical` (such as docs) keep using theirs. Adds a test asserting the homepage canonicalizes a query-string URL to the clean URL.