### PR TITLE
Improve homepage PageSpeed basics

### DIFF
--- a/app/Http/Controllers/NewsletterSubscriptionController.php
+++ b/app/Http/Controllers/NewsletterSubscriptionController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Actions\SubscribeUserToNewsletterAction;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+class NewsletterSubscriptionController
+{
+    public function __invoke(Request $request, SubscribeUserToNewsletterAction $subscribeUserToNewsletter): RedirectResponse
+    {
+        $validator = Validator::make($request->only('email'), [
+            'email' => ['required', 'email:strict,dns'],
+        ]);
+
+        if ($validator->fails()) {
+            return redirect()->to(route('home', ['newsletter' => 'invalid-email']) . '#newsletter');
+        }
+
+        $subscribeUserToNewsletter->execute(email: $validator->validated()['email']);
+
+        return redirect()->to(route('home', ['newsletter' => 'subscribed']) . '#newsletter');
+    }
+}

--- a/app/Livewire/TopSecretComponent.php
+++ b/app/Livewire/TopSecretComponent.php
@@ -145,6 +145,7 @@ class TopSecretComponent extends Component
                 'title' => 'Top Secret',
                 'bodyClass' => 'bg-bf-gray min-h-screen antialiased',
                 'image' => '/backgrounds/bf-24-desk.jpg',
+                'livewire' => true,
             ]);
     }
 }

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -19,3 +19,9 @@
     RewriteCond %{HTTP:Authorization} .
     RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 </IfModule>
+
+<IfModule mod_headers.c>
+    <FilesMatch "\.(?:css|js|mjs|woff2?|png|jpe?g|gif|webp|svg|ico)$">
+        Header set Cache-Control "public, max-age=31536000, immutable"
+    </FilesMatch>
+</IfModule>

--- a/resources/js/front/app.js
+++ b/resources/js/front/app.js
@@ -1,8 +1,17 @@
 import '../../css/front/front.css'
 
+import Alpine from 'alpinejs';
 import images from './images';
 import docs from './docs';
 // import { startAsteroids } from './asteroids';
+
+window.Alpine = Alpine;
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => Alpine.start());
+} else {
+    Alpine.start();
+}
 
 window.addEventListener('load', images);
 window.addEventListener('load', docs);

--- a/resources/js/front/gradient.jsx
+++ b/resources/js/front/gradient.jsx
@@ -1,25 +1,41 @@
-import { createRoot } from "react-dom/client";
+import { createRoot } from 'react-dom/client';
 
-document.addEventListener('livewire:navigated', async () => {
+let rendered = false;
+
+function onIdle(callback) {
+    if ('requestIdleCallback' in window) {
+        window.requestIdleCallback(callback, { timeout: 2500 });
+
+        return;
+    }
+
+    window.setTimeout(callback, 800);
+}
+
+function bootGradient() {
+    if (rendered) return;
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
     if (window.matchMedia('(max-width: 639px)').matches) return;
 
-    const element = document.getElementById("gradient");
+    const element = document.getElementById('gradient');
     if (! element) return;
 
     const url = element.dataset.url;
     if (! url) return;
 
-    const { ShaderGradientCanvas, ShaderGradient } = await import('@shadergradient/react');
+    rendered = true;
 
-    const root = createRoot(element);
-    root.render(
-        <ShaderGradientCanvas>
-            <ShaderGradient
-                control='query'
-                urlString={url}
-                enableTransition={false}
-            />
-        </ShaderGradientCanvas>
-    );
-});
+    onIdle(async () => {
+        const { ShaderGradientCanvas, ShaderGradient } = await import('@shadergradient/react');
+
+        const root = createRoot(element);
+        root.render(
+            <ShaderGradientCanvas>
+                <ShaderGradient control="query" urlString={url} enableTransition={false} />
+            </ShaderGradientCanvas>,
+        );
+    });
+}
+
+window.addEventListener('load', bootGradient, { once: true });
+document.addEventListener('livewire:navigated', bootGradient);

--- a/resources/views/front/pages/blog/index.blade.php
+++ b/resources/views/front/pages/blog/index.blade.php
@@ -4,6 +4,7 @@
     body-class="bg-oss-gray"
     main-class="font-pt text-oss-royal-blue font-medium text-18 leading-140 antialiased"
     footerCta
+    livewire
 >
     <header class="wrapper-lg px-7 sm:px-16 mt-4 lg:mt-12">
         <x-headers.super class="md:text-[96px] md:text-right text-white drop-shadow-2xl">

--- a/resources/views/front/pages/blog/show.blade.php
+++ b/resources/views/front/pages/blog/show.blade.php
@@ -5,6 +5,7 @@
     main-class="font-pt text-oss-royal-blue font-medium text-18 leading-140 antialiased"
     :description="strip_tags($post->summary)"
     footerCta
+    livewire
 >
     @if($post->og_image)
         <x-og-image :url="$post->og_image" />

--- a/resources/views/front/pages/courses/show.blade.php
+++ b/resources/views/front/pages/courses/show.blade.php
@@ -3,6 +3,7 @@
     :description="$lesson->content->description"
     body-class="bg-oss-black text-oss-gray font-medium font-pt antialiased mb-0"
     dark
+    livewire
 >
 
     @include('layout.partials.bg-color')

--- a/resources/views/front/pages/docs/index.blade.php
+++ b/resources/views/front/pages/docs/index.blade.php
@@ -2,6 +2,7 @@
     title="Documentation"
     body-class="bg-oss-gray font-pt"
     background="/backgrounds/about-blurred.jpg"
+    livewire
 >
     <section
         x-data="{

--- a/resources/views/front/pages/docs/show.blade.php
+++ b/resources/views/front/pages/docs/show.blade.php
@@ -12,6 +12,7 @@
     body-class="bg-oss-gray font-pt antialiased font-medium text-oss-royal-blue leading-[1.4]"
     :no-index="$page->alias !== $latestVersion->slug"
     canonical="{{ url('/docs/' . $repository->slug . '/' . $latestVersion->slug . '/' . $page->slug) }}"
+    livewire
 >
 
     @if($showBrandedHeader)

--- a/resources/views/front/pages/guidelines/index.blade.php
+++ b/resources/views/front/pages/guidelines/index.blade.php
@@ -1,4 +1,5 @@
 <x-page title="Guidelines" body-class="bg-oss-gray"
+    livewire
     main-class="font-pt text-oss-royal-blue font-medium text-18 leading-140 antialiased">
 
     <x-og-image view="og-image.default" :data="[

--- a/resources/views/front/pages/guidelines/show.blade.php
+++ b/resources/views/front/pages/guidelines/show.blade.php
@@ -1,6 +1,8 @@
 <x-page
     title="{{ $page->title }}"
-    body-class="bg-oss-gray font-pt antialiased font-medium text-oss-royal-blue leading-[1.4]">
+    body-class="bg-oss-gray font-pt antialiased font-medium text-oss-royal-blue leading-[1.4]"
+    livewire
+>
 
     <x-og-image view="og-image.default" :data="[
         'title' => $page->title,

--- a/resources/views/front/pages/home/index.blade.php
+++ b/resources/views/front/pages/home/index.blade.php
@@ -7,12 +7,17 @@
     body-class="bg-oss-black text-oss-gray font-medium font-pt antialiased mb-0"
     dark
     footerCta
+    :uses-session="false"
 >
     <x-slot name="description">
         Spatie builds solid websites & web applications in Laravel. With AI, we focus on solutions, not boilerplate. From Antwerp, Belgium
     </x-slot>
 
     <x-og-image view="og-image.home" />
+
+    @push('head')
+        <link rel="preload" href="{{ asset('fonts/Druk-Bold-Web.woff2') }}" as="font" type="font/woff2" crossorigin>
+    @endpush
 
     @include('layout.partials.gradient-background', [
         'color1' => '#197593',
@@ -59,8 +64,8 @@
                         <svg class="absolute top-0 right-0 w-64" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 248 248"><mask id="path-1-inside-1_home_web_2" fill="#fff"><path d="M0 0h224c13.255 0 24 10.745 24 24v224H0V0Z"/></mask><path fill="url(#paint0_linear_home_web_2)" d="M0-1h224c13.807 0 25 11.193 25 25h-2c0-12.703-10.297-23-23-23H0v-2Zm248 249H0h248ZM0 248V0v248ZM224-1c13.807 0 25 11.193 25 25v224h-2V24c0-12.703-10.297-23-23-23v-2Z" mask="url(#path-1-inside-1_home_web_2)"/><defs><linearGradient id="paint0_linear_home_web_2" x1="0" x2="197.371" y1="247.549" y2="-35.726" gradientUnits="userSpaceOnUse"><stop offset=".605" stop-opacity="0"/><stop offset="1" stop-color="#82d8af"/></linearGradient></defs></svg>
                         <h3 class="text-4xl/[0.9] font-druk uppercase text-white">Get the latest<br /> from Spatie</h3>
                         <p>Get occasional product updates, behind the scenes, and interesting links in your mailbox.</p>
-                        <div class="space-y-3">
-                            <livewire:newsletter-inline />
+                        <div id="newsletter" class="space-y-3 scroll-mt-8">
+                            @include('front.pages.home.partials.newsletter-form')
                             <p class="text-sm text-oss-gray-medium">By submitting this form, you acknowledge our <a class="underline hover:text-oss-gray-light transition-colors" href="{{ route('legal.privacy') }}">Privacy Policy</a>.</p>
                         </div>
                     </div>

--- a/resources/views/front/pages/home/partials/newsItem.blade.php
+++ b/resources/views/front/pages/home/partials/newsItem.blade.php
@@ -5,8 +5,6 @@
         @if($newsItem->is_external)
             target="_blank"
             rel="noreferrer noopener"
-        @else
-            wire:navigate.hover
         @endif
     >
         <p class="font-medium text-[20px] leading-tight mb-1 transition-colors group-hover:text-white">{{ $newsItem->title }}</p>

--- a/resources/views/front/pages/home/partials/newsletter-form.blade.php
+++ b/resources/views/front/pages/home/partials/newsletter-form.blade.php
@@ -1,0 +1,27 @@
+@if(request('newsletter') === 'subscribed')
+    <div class="leading-snug">
+        <h2 class="font-semibold text-oss-green-pale">Thank you for subscribing!</h2>
+        <p class="text-oss-gray-light text-base">You'll receive a confirmation email shortly.</p>
+    </div>
+@else
+    <form class="w-full space-y-2.5 text-base" action="{{ route('newsletter.subscribe') }}" method="POST">
+        <div class="flex-1">
+            <input
+                class="bg-white/[0.07] w-full border border-white/10 px-4 py-3 placeholder-oss-gray-dark rounded-lg transition focus:border-oss-green-pale/25 focus:outline-none"
+                name="email"
+                type="email"
+                placeholder="Email address"
+                autocomplete="email"
+                required
+            >
+
+            @if(request('newsletter') === 'invalid-email')
+                <p class="mt-1 text-oss-red text-xs">Please enter a valid email address.</p>
+            @endif
+        </div>
+
+        <button class="bg-oss-green-pale w-full px-4 py-3 text-center text-oss-gray-extra-dark rounded-lg transition hover:opacity-90" type="submit">
+            <span class="font-bold">Subscribe</span>
+        </button>
+    </form>
+@endif

--- a/resources/views/front/pages/newsletter/index.blade.php
+++ b/resources/views/front/pages/newsletter/index.blade.php
@@ -1,4 +1,5 @@
 <x-page title="Newsletter" body-class="bg-oss-gray"
+    livewire
     main-class="font-pt text-oss-royal-blue font-medium text-18 leading-140 antialiased">
 
     <x-og-image view="og-image.default" :data="[

--- a/resources/views/front/pages/open-source/index.blade.php
+++ b/resources/views/front/pages/open-source/index.blade.php
@@ -18,6 +18,7 @@ $goodFirstIssues = collect($items ?? [])->groupBy('repository_url')->sortByDesc(
     body-class="bg-oss-black text-oss-gray font-medium font-pt antialiased mb-0"
     dark
     footerCta
+    livewire
 >
 
     <x-og-image view="og-image.oss" :data="[

--- a/resources/views/front/pages/open-source/packages.blade.php
+++ b/resources/views/front/pages/open-source/packages.blade.php
@@ -3,6 +3,7 @@
     body-class="bg-oss-black text-oss-gray font-medium font-pt antialiased"
     dark
     footerCta
+    livewire
 >
 
     <x-og-image view="og-image.oss" :data="[

--- a/resources/views/front/pages/open-source/postcards.blade.php
+++ b/resources/views/front/pages/open-source/postcards.blade.php
@@ -4,6 +4,7 @@
     body-class="bg-oss-black text-oss-gray font-medium font-pt antialiased"
     dark
     footerCta
+    livewire
 >
 
     <x-og-image view="og-image.oss" :data="[

--- a/resources/views/front/profile/purchases.blade.php
+++ b/resources/views/front/profile/purchases.blade.php
@@ -2,6 +2,7 @@
     title="Purchases"
     body-class="bg-oss-black text-oss-gray font-medium font-pt antialiased mb-0"
     dark
+    livewire
 >
 
     @include('layout.partials.bg-color')

--- a/resources/views/layout/blank.blade.php
+++ b/resources/views/layout/blank.blade.php
@@ -1,10 +1,16 @@
+@props([
+    'livewire' => false,
+])
+
 <!DOCTYPE html>
 <html lang="{{ $lang ?? 'en' }}">
 
 <head>
     @include('layout.partials.meta')
 
-    @livewireStyles
+    @if($livewire)
+        @livewireStyles
+    @endif
 
     @include('layout.partials.favicons')
     @include('feed::links')
@@ -22,7 +28,9 @@
 
     <x-impersonate::banner/>
 
-    @livewireScripts
+    @if($livewire)
+        @livewireScripts
+    @endif
 
     @stack('scripts')
 

--- a/resources/views/layout/default.blade.php
+++ b/resources/views/layout/default.blade.php
@@ -1,17 +1,27 @@
+@props([
+    'comments' => false,
+    'livewire' => false,
+    'usesSession' => true,
+])
+
+@php($usesLivewire = $livewire || $comments)
+
 <!DOCTYPE html>
 <html lang="{{ $lang ?? 'en' }}">
 
 <head>
     @include('layout.partials.meta')
 
-    @livewireStyles
+    @if($usesLivewire)
+        @livewireStyles
+    @endif
 
     @include('layout.partials.favicons')
     @include('feed::links')
 
     @vite(['resources/js/front/app.js'])
 
-    @include('layout.partials.analytics')
+    @include('layout.partials.analytics', ['usesSession' => $usesSession])
 
     @stack('head')
 
@@ -34,8 +44,11 @@
     {{-- @include('layout.partials.cta') --}}
 
     {{-- @include('layout.partials.header-alert') --}}
-    @include('layout.partials.header')
-    @include('layout.partials.flash')
+    @include('layout.partials.header', ['usesSession' => $usesSession])
+
+    @if($usesSession)
+        @include('layout.partials.flash')
+    @endif
 
     <main class="flex-grow {{ $mainClass ?? '' }}">
         {{ $slot }}
@@ -43,9 +56,13 @@
 
     @include('layout.partials.footer', ['dark' => $dark ?? false, 'footerCta' => $footerCta ?? false])
 
-    <x-impersonate::banner/>
+    @if($usesSession)
+        <x-impersonate::banner/>
+    @endif
 
-    @livewireScripts
+    @if($usesLivewire)
+        @livewireScripts
+    @endif
 
     @if($comments ?? false)
         @laravelCommentsLivewireScripts

--- a/resources/views/layout/partials/analytics.blade.php
+++ b/resources/views/layout/partials/analytics.blade.php
@@ -15,7 +15,7 @@
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer', '{{$gtmId}}');</script>
 
-@if(session()->has('sold_purchasable'))
+@if(($usesSession ?? true) && session()->has('sold_purchasable'))
     <script>
         @php
             /** @var \App\Domain\Shop\Models\Purchasable|\App\Domain\Shop\Models\Bundle $purchasable */

--- a/resources/views/layout/partials/gradient-background.blade.php
+++ b/resources/views/layout/partials/gradient-background.blade.php
@@ -19,7 +19,7 @@
 @push('startBody')
     @if($mobilePlaceholder)
         <div class="sm:motion-safe:hidden absolute top-0 left-0 right-0 z-0 pointer-events-none">
-            <img src="{{ $mobilePlaceholder }}" class="w-full aspect-[9/16] object-cover" alt="" fetchpriority=high>
+            <img src="{{ $mobilePlaceholder }}" class="w-full aspect-[9/16] object-cover" alt="" fetchpriority="high">
             <div class="absolute inset-0 z-10 w-full h-full bg-gradient-to-b from-transparent to-oss-black"></div>
         </div>
     @endif

--- a/resources/views/layout/partials/header.blade.php
+++ b/resources/views/layout/partials/header.blade.php
@@ -59,6 +59,7 @@
 
                     <div
                         x-show="ossOpen || isMobile"
+                        x-cloak
                         x-transition:enter="transition ease-out duration-100"
                         x-transition:enter-start="opacity-0 scale-95"
                         x-transition:enter-end="opacity-100 scale-100"

--- a/resources/views/layout/partials/header.blade.php
+++ b/resources/views/layout/partials/header.blade.php
@@ -111,7 +111,7 @@
 
             {{-- Right side: Login + CTA --}}
             <div class="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4 mt-4 sm:mt-0 print:hidden">
-                @auth
+                @if($usesSession && auth()->check())
                     @include('layout.partials.navigation.profileIcon', ['url' => route('profile'), 'active' => request()->is('profile*')])
                 @else
                     <a
@@ -121,7 +121,7 @@
                         <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" /></svg>
                         Login
                     </a>
-                @endauth
+                @endif
 
                 <a
                     href="#match"

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,6 +18,7 @@ use App\Http\Controllers\DownloadRayV3Controller;
 use App\Http\Controllers\ExternalFeedItemsController;
 use App\Http\Controllers\BlogController;
 use App\Http\Controllers\MusicController;
+use App\Http\Controllers\NewsletterSubscriptionController;
 use App\Http\Controllers\PackageHeaderController;
 use App\Http\Controllers\RegenerateLicenseKeyController;
 use App\Http\Controllers\ShowReleaseNotesController;
@@ -39,7 +40,9 @@ use App\Http\Controllers\CoursesController;
 use App\Http\Controllers\WebhookController;
 use App\Http\Controllers\WwsdController;
 use App\Http\Middleware\TopSecretMiddleware;
+use Illuminate\Session\Middleware\StartSession;
 use Illuminate\Support\Facades\Route;
+use Illuminate\View\Middleware\ShareErrorsFromSession;
 use Spatie\MarkdownResponse\Middleware\ProvideMarkdownResponse;
 
 Route::domain('topsecret.'.config('app.url'))->group(function () {
@@ -81,7 +84,16 @@ Route::domain('guidelines.spatie.be')->group(function () {
 
 Route::get('llms.txt', LlmsTxtController::class);
 
-Route::view('/', 'front.pages.home.index')->name('home');
+Route::view('/', 'front.pages.home.index')
+    ->withoutMiddleware([
+        StartSession::class,
+        ShareErrorsFromSession::class,
+    ])
+    ->name('home');
+
+Route::post('newsletter-subscriptions', NewsletterSubscriptionController::class)
+    ->middleware('throttle:5,1')
+    ->name('newsletter.subscribe');
 
 Route::view('web-development', 'front.pages.web-development.index')->name('web-development');
 

--- a/tests/Feature/NewsletterSubscriptionControllerTest.php
+++ b/tests/Feature/NewsletterSubscriptionControllerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use App\Actions\SubscribeUserToNewsletterAction;
+
+it('subscribes an email address to the newsletter', function () {
+    $this->mock(SubscribeUserToNewsletterAction::class)
+        ->shouldReceive('execute')
+        ->once()
+        ->withArgs(
+            fn (?object $user = null, ?string $email = null) => $user === null && $email === 'hello@spatie.be'
+        );
+
+    $this
+        ->post(route('newsletter.subscribe'), ['email' => 'hello@spatie.be'])
+        ->assertRedirect(route('home', ['newsletter' => 'subscribed']) . '#newsletter');
+});
+
+it('redirects back to the homepage when the newsletter email is invalid', function () {
+    $this->mock(SubscribeUserToNewsletterAction::class)
+        ->shouldNotReceive('execute');
+
+    $this
+        ->post(route('newsletter.subscribe'), ['email' => 'not-an-email'])
+        ->assertRedirect(route('home', ['newsletter' => 'invalid-email']) . '#newsletter');
+});

--- a/tests/Feature/Pages/FrontendAssetsTest.php
+++ b/tests/Feature/Pages/FrontendAssetsTest.php
@@ -2,6 +2,9 @@
 
 use Database\Seeders\DocsSeeder;
 use Illuminate\Testing\TestResponse;
+use Illuminate\Session\Middleware\StartSession;
+use Illuminate\Support\Facades\Route;
+use Illuminate\View\Middleware\ShareErrorsFromSession;
 
 function assertLivewireAssetsAreLoaded(TestResponse $response): void
 {
@@ -9,6 +12,14 @@ function assertLivewireAssetsAreLoaded(TestResponse $response): void
         ->toContain('Livewire Styles')
         ->toContain('Livewire Scripts')
         ->toContain('data-update-uri');
+}
+
+function assertLivewireAssetsAreNotLoaded(TestResponse $response): void
+{
+    expect($response->getContent())
+        ->not->toContain('Livewire Styles')
+        ->not->toContain('Livewire Scripts')
+        ->not->toContain('data-update-uri');
 }
 
 function assertCommentAndSimpleMdeAssetsAreNotLoaded(TestResponse $response): void
@@ -19,17 +30,36 @@ function assertCommentAndSimpleMdeAssetsAreNotLoaded(TestResponse $response): vo
         ->not->toContain('SimpleMDE');
 }
 
-it('loads livewire assets on a static page for alpine and navigation', function () {
+it('does not load livewire assets on a static page', function () {
     $response = $this->get(route('legal.index'));
 
     $response->assertOk();
 
-    assertLivewireAssetsAreLoaded($response);
+    assertLivewireAssetsAreNotLoaded($response);
     assertCommentAndSimpleMdeAssetsAreNotLoaded($response);
 });
 
-it('loads livewire assets on livewire pages', function () {
+it('does not load livewire assets on the homepage', function () {
     $response = $this->get(route('home'));
+
+    $response->assertOk();
+
+    assertLivewireAssetsAreNotLoaded($response);
+    assertCommentAndSimpleMdeAssetsAreNotLoaded($response);
+    expect($response->getContent())
+        ->toContain('newsletter-subscriptions')
+        ->toContain('fonts/Druk-Bold-Web.woff2')
+        ->not->toContain('newsletter-inline');
+});
+
+it('does not start a session on the homepage', function () {
+    expect(Route::getRoutes()->getByName('home')->excludedMiddleware())
+        ->toContain(StartSession::class)
+        ->toContain(ShareErrorsFromSession::class);
+});
+
+it('loads livewire assets on livewire pages', function () {
+    $response = $this->get(route('newsletter'));
 
     $response->assertOk();
 
@@ -58,7 +88,6 @@ it('does not load comment or simplemde assets on normal pages', function (string
 
     assertCommentAndSimpleMdeAssetsAreNotLoaded($response);
 })->with([
-    'home' => ['/'],
     'docs' => ['/docs'],
     'legal' => ['/legal'],
     'guidelines' => ['/guidelines'],

--- a/tests/Feature/Pages/FrontendAssetsTest.php
+++ b/tests/Feature/Pages/FrontendAssetsTest.php
@@ -1,9 +1,9 @@
 <?php
 
 use Database\Seeders\DocsSeeder;
-use Illuminate\Testing\TestResponse;
 use Illuminate\Session\Middleware\StartSession;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Testing\TestResponse;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
 
 function assertLivewireAssetsAreLoaded(TestResponse $response): void


### PR DESCRIPTION
## Summary
- make Livewire assets opt-in and remove Livewire from the homepage newsletter/news critical path
- add a normal throttled newsletter subscription POST flow for the homepage
- defer the shader gradient import until after load/idle and preload the Druk heading font
- add immutable cache headers for static Apache-served assets
- skip session middleware on the homepage while preserving it on Livewire/auth flows

## Tests
- ./vendor/bin/pest tests/Feature/Pages/FrontendAssetsTest.php tests/Feature/NewsletterSubscriptionControllerTest.php
- php artisan test tests/Feature/Pages/FrontendAssetsTest.php tests/Feature/NewsletterSubscriptionControllerTest.php
- npm run build

Note: local curl header checks through artisan serve were polluted by Debugbar headers/cookies; Apache .htaccess cache headers cannot be verified through artisan serve.