### PR TITLE
Use database-backed docs search

### DIFF
--- a/app/Livewire/SearchDocsComponent.php
+++ b/app/Livewire/SearchDocsComponent.php
@@ -43,14 +43,10 @@ class SearchDocsComponent extends Component
         return Search::onIndex($this->indexName())
             ->limit(20)
             ->query($this->query)
-            ->searchParameters(
-                ['filter' => [
-                    "version = '{$version}'",
-                    "repo = '{$repo}'",
-
-                ],
-                ]
-            )
+            ->searchParameters(['filters' => [
+                'version' => $version,
+                'repo' => $repo,
+            ]])
             ->get()
             ->hits;
     }

--- a/app/Support/Search/DocsSearchDatabaseDriver.php
+++ b/app/Support/Search/DocsSearchDatabaseDriver.php
@@ -20,7 +20,7 @@ class DocsSearchDatabaseDriver extends DatabaseDriver
             throw new RuntimeException('The docs search database driver requires MySQL or MariaDB.');
         }
 
-        return new self($connection, new DocsSearchMySqlGrammar);
+        return new self($connection, new DocsSearchMySqlGrammar());
     }
 
     public function search(

--- a/app/Support/Search/DocsSearchDatabaseDriver.php
+++ b/app/Support/Search/DocsSearchDatabaseDriver.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Support\Search;
+
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+use Spatie\SiteSearch\Drivers\DatabaseDriver;
+use Spatie\SiteSearch\Models\SiteSearchConfig;
+use Spatie\SiteSearch\SearchResults\Hit;
+use Spatie\SiteSearch\SearchResults\SearchResults;
+
+class DocsSearchDatabaseDriver extends DatabaseDriver
+{
+    public static function make(SiteSearchConfig $config): self
+    {
+        $connectionName = $config->getExtraValue('database.connection');
+        $connection = DB::connection($connectionName);
+
+        if (! in_array($connection->getDriverName(), ['mysql', 'mariadb'], strict: true)) {
+            throw new RuntimeException('The docs search database driver requires MySQL or MariaDB.');
+        }
+
+        return new self($connection, new DocsSearchMySqlGrammar);
+    }
+
+    public function search(
+        string $indexName,
+        string $query,
+        ?int $limit = null,
+        int $offset = 0,
+        array $searchParameters = [],
+    ): SearchResults {
+        $startTime = microtime(true);
+        $effectiveLimit = $limit ?? 20;
+        $filters = $searchParameters['filters'] ?? [];
+
+        /** @var DocsSearchMySqlGrammar $grammar */
+        $grammar = $this->grammar;
+
+        $grammar->ensureFtsSetup($this->connection);
+
+        $results = $grammar->searchWithFilters(
+            $this->connection,
+            $indexName,
+            $query,
+            $effectiveLimit,
+            $offset,
+            $filters,
+        );
+
+        $totalCount = $grammar->getTotalCountWithFilters(
+            $this->connection,
+            $indexName,
+            $query,
+            $filters,
+        );
+
+        $hits = collect($results)
+            ->map(fn (array $row) => new Hit($this->buildHitProperties($row)));
+
+        return new SearchResults(
+            $hits,
+            (int) ((microtime(true) - $startTime) * 1000),
+            $totalCount,
+            $effectiveLimit,
+            $offset,
+        );
+    }
+}

--- a/app/Support/Search/DocsSearchMySqlGrammar.php
+++ b/app/Support/Search/DocsSearchMySqlGrammar.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Support\Search;
+
+use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Builder;
+use InvalidArgumentException;
+use Spatie\SiteSearch\Drivers\Database\MySqlGrammar;
+
+class DocsSearchMySqlGrammar extends MySqlGrammar
+{
+    protected const AllowedFilters = ['repo', 'version'];
+
+    public function searchWithFilters(
+        Connection $connection,
+        string $indexName,
+        string $query,
+        int $limit,
+        int $offset,
+        array $filters,
+    ): array {
+        if (empty(trim($query))) {
+            return $this->applyFilters(
+                $connection->table('site_search_documents')
+                    ->where('index_name', $indexName),
+                $filters,
+            )
+                ->orderByDesc('date_modified_timestamp')
+                ->limit($limit)
+                ->offset($offset)
+                ->get()
+                ->map(fn ($row) => (array) $row)
+                ->all();
+        }
+
+        $searchTerms = $this->prepareBooleanQuery($query);
+
+        $results = $connection->table('site_search_documents')
+            ->select('*')
+            ->selectRaw(
+                'MATCH(entry, page_title, h1, description, url) AGAINST(? IN BOOLEAN MODE) as relevance',
+                [$searchTerms],
+            )
+            ->where('index_name', $indexName)
+            ->whereRaw(
+                'MATCH(entry, page_title, h1, description, url) AGAINST(? IN BOOLEAN MODE)',
+                [$searchTerms],
+            );
+
+        return $this->applyFilters($results, $filters)
+            ->orderByDesc('relevance')
+            ->limit($limit)
+            ->offset($offset)
+            ->get()
+            ->map(fn ($row) => $this->addHighlighting((array) $row, $query))
+            ->all();
+    }
+
+    public function getTotalCountWithFilters(
+        Connection $connection,
+        string $indexName,
+        string $query,
+        array $filters,
+    ): int {
+        $queryBuilder = $connection->table('site_search_documents')
+            ->where('index_name', $indexName);
+
+        if (! empty(trim($query))) {
+            $searchTerms = $this->prepareBooleanQuery($query);
+
+            $queryBuilder->whereRaw(
+                'MATCH(entry, page_title, h1, description, url) AGAINST(? IN BOOLEAN MODE)',
+                [$searchTerms],
+            );
+        }
+
+        return $this->applyFilters($queryBuilder, $filters)->count();
+    }
+
+    protected function applyFilters(Builder $query, array $filters): Builder
+    {
+        foreach ($filters as $name => $value) {
+            if (! in_array($name, self::AllowedFilters, strict: true)) {
+                throw new InvalidArgumentException("Unsupported docs search filter: {$name}");
+            }
+
+            $query->where("extra->{$name}", $value);
+        }
+
+        return $query;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,6 @@
         "league/commonmark": "^2.2.1",
         "league/flysystem-aws-s3-v3": "^3.10",
         "livewire/livewire": "^4.0",
-        "meilisearch/meilisearch-php": "^1.0",
         "myclabs/php-enum": "^1.8.4",
         "nyholm/psr7": "^1.5.1",
         "ohdearapp/ohdear-php-sdk": "^3.4.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cdcc8a71dc49c447963252942b1ade06",
+    "content-hash": "ba1e3e085644b6aed2b8b8d52886f09d",
     "packages": [
         {
             "name": "abraham/twitteroauth",
@@ -6025,86 +6025,6 @@
                 "source": "https://github.com/maxmind/web-service-common-php/tree/v0.11.1"
             },
             "time": "2026-01-13T17:56:03+00:00"
-        },
-        {
-            "name": "meilisearch/meilisearch-php",
-            "version": "v1.16.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/meilisearch/meilisearch-php.git",
-                "reference": "f9f63e0e7d12ffaae54f7317fa8f4f4dfa8ae7b6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/meilisearch/meilisearch-php/zipball/f9f63e0e7d12ffaae54f7317fa8f4f4dfa8ae7b6",
-                "reference": "f9f63e0e7d12ffaae54f7317fa8f4f4dfa8ae7b6",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "php": "^7.4 || ^8.0",
-                "php-http/discovery": "^1.7",
-                "psr/http-client": "^1.0",
-                "symfony/polyfill-php81": "^1.33"
-            },
-            "require-dev": {
-                "http-interop/http-factory-guzzle": "^1.2.0",
-                "php-cs-fixer/shim": "^3.59.3",
-                "phpstan/phpstan": "^2.0",
-                "phpstan/phpstan-deprecation-rules": "^2.0",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpstan/phpstan-strict-rules": "^2.0",
-                "phpunit/phpunit": "^9.5 || ^10.5",
-                "symfony/http-client": "^5.4|^6.0|^7.0"
-            },
-            "suggest": {
-                "guzzlehttp/guzzle": "Use Guzzle ^7 as HTTP client",
-                "http-interop/http-factory-guzzle": "Factory for guzzlehttp/guzzle",
-                "symfony/http-client": "Use Symfony Http client"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "MeiliSearch\\": "src/",
-                    "Meilisearch\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Clémentine Urquizar",
-                    "email": "clementine@meilisearch.com"
-                },
-                {
-                    "name": "Bruno Casali",
-                    "email": "bruno@meilisearch.com"
-                },
-                {
-                    "name": "Laurent Cazanove",
-                    "email": "lau.cazanove@gmail.com"
-                },
-                {
-                    "name": "Tomas Norkūnas",
-                    "email": "norkunas.tom@gmail.com"
-                }
-            ],
-            "description": "PHP wrapper for the Meilisearch API",
-            "keywords": [
-                "api",
-                "client",
-                "instant",
-                "meilisearch",
-                "php",
-                "search"
-            ],
-            "support": {
-                "issues": "https://github.com/meilisearch/meilisearch-php/issues",
-                "source": "https://github.com/meilisearch/meilisearch-php/tree/v1.16.1"
-            },
-            "time": "2025-09-18T10:15:45+00:00"
         },
         {
             "name": "moneyphp/money",
@@ -16472,86 +16392,6 @@
                 }
             ],
             "time": "2026-04-10T16:19:22+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php81",
-            "version": "v1.38.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php81.git",
-                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
-                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php81\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.1+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.38.1"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-05-26T12:45:58+00:00"
         },
         {
             "name": "symfony/polyfill-php82",

--- a/config/site-search.php
+++ b/config/site-search.php
@@ -64,7 +64,7 @@ return [
      * A driver is responsible for writing all scraped content
      * to a search index.
      */
-    'default_driver' => Spatie\SiteSearch\Drivers\MeiliSearchDriver::class,
+    'default_driver' => App\Support\Search\DocsSearchDatabaseDriver::class,
 
     /*
      * This job is responsible for crawling your site. To customize this job,

--- a/database/migrations/2026_07_15_000000_add_database_driver_support_to_site_search.php
+++ b/database/migrations/2026_07_15_000000_add_database_driver_support_to_site_search.php
@@ -5,7 +5,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class () extends Migration {
     public function up(): void
     {
         Schema::table('site_search_configs', function (Blueprint $table) {

--- a/database/migrations/2026_07_15_000000_add_database_driver_support_to_site_search.php
+++ b/database/migrations/2026_07_15_000000_add_database_driver_support_to_site_search.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('site_search_configs', function (Blueprint $table) {
+            $table->integer('urls_found')->default(0);
+            $table->integer('urls_failed')->default(0);
+            $table->string('finish_reason')->nullable();
+        });
+
+        Schema::create('site_search_documents', function (Blueprint $table) {
+            $table->id();
+            $table->string('index_name')->index();
+            $table->string('document_id');
+            $table->text('url');
+            $table->text('anchor')->nullable();
+            $table->text('page_title')->nullable();
+            $table->text('h1')->nullable();
+            $table->longText('entry')->nullable();
+            $table->text('description')->nullable();
+            $table->integer('date_modified_timestamp')->nullable();
+            $table->json('extra')->nullable();
+            $table->timestamps();
+
+            $table->unique(['index_name', 'document_id']);
+        });
+
+        DB::table('site_search_configs')
+            ->where('name', 'docs')
+            ->update(['driver_class' => null]);
+    }
+};

--- a/database/seeders/SiteSearchSeeder.php
+++ b/database/seeders/SiteSearchSeeder.php
@@ -14,15 +14,6 @@ class SiteSearchSeeder extends Seeder
             'index_base_name' => 'docs',
             'crawl_url' => 'https://spatie.be.test/docs',
             'enabled' => 1,
-            'extra' => [
-                'meilisearch' => [
-                    // apiKey => '', // for production
-                    'indexSettings' => [
-                        'filterableAttributes' => ['version', 'repo'],
-                        'searchableAttributes' => ['pageTitle', 'description', 'entry'],
-                    ],
-                ],
-            ],
         ]);
     }
 }

--- a/resources/views/front/pages/docs/partials/search.blade.php
+++ b/resources/views/front/pages/docs/partials/search.blade.php
@@ -27,8 +27,8 @@
             @forelse ($hits as $index => $hit)
                 <li wire:key="{{ $hit->id }}" class="block">
                     <a id="hit-{{ $index }}" :class="selectedHit == {{ $index }} ? 'bg-blue-light text-white' : 'bg-gray-100'" class="block outline-none hover:bg-blue-light focus:text-white hover:text-white group px-4 py-3 rounded" href="{{ $hit->url }}">
-                        <p class="mb-1" x-html="@js($hit->title()).replace(/({{ $query }})/gi, '<strong class=\'underline group-hover:text-white group-focus:text-white'+ (selectedHit == {{ $index }} ? 'text-white' : 'text-blue-light') +'\'>$1</strong>')"></p>
-                        <p class="text-sm" x-html="@js($hit->entry).replace(/({{ $query }})/gi, '<strong class=\'underline group-hover:text-white group-focus:text-white'+ (selectedHit == {{ $index }} ? 'text-white' : 'text-blue-light') +'\'>$1</strong>')"></p>
+                        <p class="mb-1" x-text="@js($hit->title())"></p>
+                        <p class="text-sm [&_em]:font-bold [&_em]:underline" x-html="@js($hit->highlightedSnippet() ?? $hit->snippet())"></p>
                     </a>
                 </li>
             @empty


### PR DESCRIPTION
## Summary

- replace Meilisearch with the database-backed site search driver
- add the site search documents and crawl progress schema
- preserve repository and version filtering for MySQL/MariaDB
- render bounded, highlighted snippets from database search results
- remove the unused Meilisearch PHP client

## Testing

- `composer validate --no-check-publish`
- standalone PHPStan analysis for the changed PHP classes
- site search migrations against a fresh SQLite schema
- `php artisan view:cache`
- `npm run build`

The full Pest suite was not run because the configured local MySQL server is unavailable.
