### PR TITLE
Index non-latest docs versions

### DIFF
--- a/app/Support/Search/DocsSearchProfile.php
+++ b/app/Support/Search/DocsSearchProfile.php
@@ -17,6 +17,8 @@ class DocsSearchProfile extends DefaultSearchProfile
 
     public function configureCrawler(Crawler $crawler): void
     {
-        $crawler->concurrency(5);
+        // Non-latest docs versions are served with a `noindex` robots meta tag for SEO.
+        // Respecting it here would keep them out of our own docs search as well.
+        $crawler->concurrency(5)->ignoreRobots();
     }
 }

--- a/tests/Support/Search/DocsSearchProfileTest.php
+++ b/tests/Support/Search/DocsSearchProfileTest.php
@@ -1,0 +1,12 @@
+<?php
+
+use App\Support\Search\DocsSearchProfile;
+use Spatie\Crawler\Crawler;
+
+it('does not respect robots, so that non-latest docs versions get indexed', function () {
+    $crawler = Crawler::create('https://spatie.be/docs');
+
+    (new DocsSearchProfile())->configureCrawler($crawler);
+
+    expect($crawler->mustRespectRobots())->toBeFalse();
+});


### PR DESCRIPTION
Docs search returns nothing on every version except the latest one. Verified live: 53/53 latest versions return hits, 14/14 non-latest versions return zero for any query.

`show.blade.php` sets `no-index` on non-latest versions for SEO, which renders `<meta name="robots" content="noindex">`. `spatie/crawler` respects robots by default and only calls the indexing observer when `$robots->mayIndex()`, so those pages get crawled (links are still followed) but never reach `DocsSearchIndexer`. `SearchDocsComponent` then filters on the version from the current URL, which isn't in the index.

Calling `ignoreRobots()` in `DocsSearchProfile::configureCrawler()` fixes it. Safe here: this profile only crawls `/docs`, and our robots.txt disallows nothing. The SEO noindex stays intact for Google.

This is what spatie/laravel-activitylog#1459 reported, seen from the other side. Back then spatie.be still treated v4 as latest, so v5 was the noindexed one. That has since flipped, so today v4 is the broken one.

Two unrelated things in the same file I left alone: `shouldIndex()` unconditionally returns `true`, bypassing the parent's non-200 and `site-search-do-not-index` header checks, and both `shouldIndex()` and `DocsSearchIndexer::extra()` call `info()` on every crawled URL.