### PR TITLE
Show the ad configured on a repository in its docs sidebar

### DIFF
--- a/app/Filament/Resources/Content/AdResource.php
+++ b/app/Filament/Resources/Content/AdResource.php
@@ -11,6 +11,7 @@ use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Resources\Resource;
@@ -46,6 +47,11 @@ class AdResource extends Resource
                     ->columnStart(1)
                     ->required()
                     ->url(),
+                Select::make('banner_component')
+                    ->label('Banner')
+                    ->helperText('Shown on the docs pages of repositories using this ad. Leave empty to show a random banner.')
+                    ->options(Ad::availableBannerComponents())
+                    ->columnStart(1),
                 Toggle::make('active')
                     ->columnStart(1),
             ]);
@@ -63,6 +69,9 @@ class AdResource extends Resource
                     ->openUrlInNewTab()
                     ->searchable()
                     ->sortable(),
+                TextColumn::make('banner_component')
+                    ->label('Banner')
+                    ->placeholder('random'),
                 BooleanColumn::make('active'),
             ])
             ->filters([

--- a/app/Http/Controllers/DocsController.php
+++ b/app/Http/Controllers/DocsController.php
@@ -146,8 +146,6 @@ class DocsController
 
         $showBrandedHeader = $repositoryModel && isset($repositoryModel->logo_svg) && isset($repositoryModel->accent_color);
 
-        ray('show branded header?', $showBrandedHeader, $repositoryModel);
-
         $tableOfContents = $this->extractTableOfContents($page->contents);
 
         return view('front.pages.docs.show', compact(

--- a/app/Models/Ad.php
+++ b/app/Models/Ad.php
@@ -7,6 +7,9 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use SplFileInfo;
 
 class Ad extends Model
 {
@@ -40,6 +43,32 @@ class Ad extends Model
     public function scopeActive(Builder $query): void
     {
         $query->where('active', true);
+    }
+
+    /** @return array<string, string> */
+    public static function availableBannerComponents(): array
+    {
+        return collect(File::files(resource_path('views/components/banners')))
+            ->map(fn (SplFileInfo $file) => Str::before($file->getFilename(), '.blade.php'))
+            ->reject(fn (string $component) => $component === 'randomBanner')
+            ->sort()
+            ->mapWithKeys(fn (string $component) => [$component => $component])
+            ->all();
+    }
+
+    public function bannerView(): ?string
+    {
+        if (! $this->active) {
+            return null;
+        }
+
+        if (! $this->banner_component) {
+            return null;
+        }
+
+        $view = "components.banners.{$this->banner_component}";
+
+        return view()->exists($view) ? $view : null;
     }
 
     /** @return HasMany<Repository, $this> */

--- a/app/Models/Repository.php
+++ b/app/Models/Repository.php
@@ -151,6 +151,11 @@ class Repository extends Model implements HasMedia
         );
     }
 
+    public function adBannerView(): ?string
+    {
+        return $this->ad?->bannerView();
+    }
+
     public function hasAdWithImage(): bool
     {
         if (! $ad = $this->ad) {

--- a/database/migrations/2026_08_31_100000_add_banner_component_to_ads_table.php
+++ b/database/migrations/2026_08_31_100000_add_banner_component_to_ads_table.php
@@ -1,0 +1,63 @@
+<?php
+
+use App\Models\Ad;
+use App\Models\Repository;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+return new class () extends Migration {
+    /**
+     * These repositories had their banner hardcoded in randomBanner.blade.php.
+     * They now advertise themselves through their ad instead.
+     *
+     * @var array<string, array{ad: string, banner: string}>
+     */
+    protected array $ownAdPerRepository = [
+        'laravel-medialibrary' => ['ad' => 'Media Library Pro', 'banner' => 'medialibrary'],
+        'laravel-event-sourcing' => ['ad' => 'Event Sourcing in Laravel', 'banner' => 'event-sourcing'],
+    ];
+
+    public function up()
+    {
+        if (! Schema::hasColumn('ads', 'banner_component')) {
+            Schema::table('ads', function (Blueprint $table) {
+                $table->string('banner_component')->nullable();
+            });
+        }
+
+        $this->linkAdsNamedAfterTheirBanner();
+
+        foreach ($this->ownAdPerRepository as $repositoryName => $own) {
+            $this->pinRepositoryToItsOwnAd($repositoryName, $own['ad'], $own['banner']);
+        }
+    }
+
+    protected function linkAdsNamedAfterTheirBanner(): void
+    {
+        Ad::query()->each(function (Ad $ad) {
+            $banner = Str::slug($ad->name);
+
+            if (! view()->exists("components.banners.{$banner}")) {
+                return;
+            }
+
+            $ad->update(['banner_component' => $banner]);
+        });
+    }
+
+    protected function pinRepositoryToItsOwnAd(string $repositoryName, string $adName, string $banner): void
+    {
+        $repository = Repository::query()->where('name', $repositoryName)->first();
+        $ad = Ad::query()->where('name', $adName)->first();
+
+        if (! $repository || ! $ad) {
+            return;
+        }
+
+        $ad->update(['banner_component' => $banner, 'active' => true]);
+
+        $repository->update(['ad_id' => $ad->id, 'ad_should_be_randomized' => false]);
+    }
+};

--- a/resources/views/components/banners/randomBanner.blade.php
+++ b/resources/views/components/banners/randomBanner.blade.php
@@ -1,15 +1,14 @@
-@if(isset($repository) && $repository->slug === 'laravel-medialibrary')
-    @include('components.banners.medialibrary')
-@elseif(isset($repository) && $repository->slug === 'laravel-event-sourcing')
-    @include('components.banners.event-sourcing')
-@else
-    @include(\Illuminate\Support\Arr::random([
-        'components.banners.medialibrary',
-        'components.banners.crud',
-        'components.banners.flare',
-        'components.banners.mailcoach',
-        'components.banners.ray',
-        {{-- 'components.banners.testingLaravel', --}}
-        {{-- 'components.banners.writing-readable-php', --}}
-    ]))
-@endif
+@php
+    $banner = ($repositoryModel ?? null)?->adBannerView()
+        ?? \Illuminate\Support\Arr::random([
+            'components.banners.medialibrary',
+            'components.banners.crud',
+            'components.banners.flare',
+            'components.banners.mailcoach',
+            'components.banners.ray',
+            // 'components.banners.testingLaravel',
+            // 'components.banners.writing-readable-php',
+        ]);
+@endphp
+
+@include($banner)

--- a/resources/views/front/pages/docs/show.blade.php
+++ b/resources/views/front/pages/docs/show.blade.php
@@ -192,7 +192,7 @@
                         </ul>
                     @endif
 
-                    @include('components.banners.randomBanner', ['repository' => $repository])
+                    @include('components.banners.randomBanner', ['repositoryModel' => $repositoryModel])
 
                     <a href="{{ $alias->githubUrl }}/blob/{{$alias->branch}}/docs/{{ $page->slug }}.md" target="_blank"
                        class="text-sm inline-flex items-center gap-3 mt-10 hover:underline">

--- a/tests/Feature/DocsBanner/AddBannerComponentToAdsMigrationTest.php
+++ b/tests/Feature/DocsBanner/AddBannerComponentToAdsMigrationTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use App\Models\Ad;
+use App\Models\Repository;
+use Illuminate\Support\Facades\Storage;
+
+beforeEach(function () {
+    Storage::fake('github_ads');
+
+    $this->migration = require database_path('migrations/2026_08_31_100000_add_banner_component_to_ads_table.php');
+});
+
+it('links ads that are named after their banner', function () {
+    $flare = Ad::factory()->create(['name' => 'Flare', 'banner_component' => null]);
+    $mailcoach = Ad::factory()->create(['name' => 'Mailcoach', 'banner_component' => null]);
+    $blackFriday = Ad::factory()->create(['name' => 'Black Friday', 'banner_component' => null]);
+
+    $this->migration->up();
+
+    expect($flare->fresh()->banner_component)->toBe('flare')
+        ->and($mailcoach->fresh()->banner_component)->toBe('mailcoach')
+        ->and($blackFriday->fresh()->banner_component)->toBeNull();
+});
+
+it('points the repositories that had a hardcoded banner at their own ad', function () {
+    $flare = Ad::factory()->active()->create(['name' => 'Flare']);
+    $mediaLibrary = Ad::factory()->inactive()->create(['name' => 'Media Library Pro']);
+    $eventSourcing = Ad::factory()->inactive()->create(['name' => 'Event Sourcing in Laravel']);
+
+    $mediaLibraryRepository = Repository::factory()->create([
+        'name' => 'laravel-medialibrary',
+        'ad_id' => $flare->id,
+        'ad_should_be_randomized' => true,
+    ]);
+    $eventSourcingRepository = Repository::factory()->create([
+        'name' => 'laravel-event-sourcing',
+        'ad_id' => $flare->id,
+        'ad_should_be_randomized' => true,
+    ]);
+
+    $this->migration->up();
+
+    expect($mediaLibraryRepository->fresh()->ad_id)->toBe($mediaLibrary->id)
+        ->and($mediaLibraryRepository->fresh()->ad_should_be_randomized)->toBeFalse()
+        ->and($mediaLibrary->fresh()->active)->toBeTrue()
+        ->and($mediaLibrary->fresh()->banner_component)->toBe('medialibrary');
+
+    expect($eventSourcingRepository->fresh()->ad_id)->toBe($eventSourcing->id)
+        ->and($eventSourcingRepository->fresh()->ad_should_be_randomized)->toBeFalse()
+        ->and($eventSourcing->fresh()->active)->toBeTrue()
+        ->and($eventSourcing->fresh()->banner_component)->toBe('event-sourcing');
+});
+
+it('renders the medialibrary banner on the medialibrary docs after migrating', function () {
+    Ad::factory()->inactive()->create(['name' => 'Media Library Pro']);
+    $repository = Repository::factory()->create(['name' => 'laravel-medialibrary', 'ad_id' => null]);
+
+    $this->migration->up();
+
+    $rendered = renderRandomBanner(['repositoryModel' => $repository->fresh()]);
+
+    expect($rendered)->toContain('medialibrary.pro');
+});
+
+it('leaves repositories without a matching ad alone', function () {
+    $repository = Repository::factory()->create(['name' => 'laravel-medialibrary', 'ad_id' => null]);
+
+    $this->migration->up();
+
+    expect($repository->fresh()->ad_id)->toBeNull();
+});

--- a/tests/Feature/DocsBanner/DocsBannerTest.php
+++ b/tests/Feature/DocsBanner/DocsBannerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+use App\Models\Ad;
+use App\Models\Repository;
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Storage;
+
+beforeEach(function () {
+    Storage::fake('github_ads');
+});
+
+it('offers every banner component as an option, except the random one', function () {
+    $components = Ad::availableBannerComponents();
+
+    expect($components)
+        ->toHaveKey('flare')
+        ->toHaveKey('mailcoach')
+        ->not->toHaveKey('randomBanner');
+});
+
+it('returns the banner configured on the ad', function () {
+    $ad = Ad::factory()->active()->create(['banner_component' => 'flare']);
+
+    expect($ad->bannerView())->toBe('components.banners.flare');
+});
+
+it('returns no banner when the ad has none configured', function () {
+    $ad = Ad::factory()->active()->create(['banner_component' => null]);
+
+    expect($ad->bannerView())->toBeNull();
+});
+
+it('returns no banner when the configured component no longer exists', function () {
+    $ad = Ad::factory()->active()->create(['banner_component' => 'removed-banner']);
+
+    expect($ad->bannerView())->toBeNull();
+});
+
+it('returns no banner when the ad is inactive', function () {
+    $ad = Ad::factory()->inactive()->create(['banner_component' => 'flare']);
+
+    expect($ad->bannerView())->toBeNull();
+});
+
+it('exposes the banner of the ad associated with a repository', function () {
+    $ad = Ad::factory()->active()->create(['banner_component' => 'flare']);
+    $repository = Repository::factory()->create(['ad_id' => $ad->id]);
+
+    expect($repository->adBannerView())->toBe('components.banners.flare');
+});
+
+it('exposes no banner for a repository without an ad', function () {
+    $repository = Repository::factory()->create(['ad_id' => null]);
+
+    expect($repository->adBannerView())->toBeNull();
+});
+
+it('always renders the ad of the repository instead of a random banner', function () {
+    $ad = Ad::factory()->active()->create(['banner_component' => 'flare']);
+    $repository = Repository::factory()->create(['ad_id' => $ad->id]);
+
+    foreach (range(1, 20) as $ignored) {
+        $rendered = renderRandomBanner(['repositoryModel' => $repository->fresh()]);
+
+        expect($rendered)->toContain('flareapp.io');
+    }
+});
+
+it('falls back to a random banner when the repository has no ad', function () {
+    $repository = Repository::factory()->create(['ad_id' => null]);
+
+    $rendered = renderRandomBanner(['repositoryModel' => $repository]);
+
+    expect($rendered)->toContain('?ref=spatie-docs');
+});
+
+it('renders a random banner when no repository is given', function () {
+    $rendered = renderRandomBanner();
+
+    expect($rendered)->toContain('?ref=spatie-docs');
+});
+
+it('passes the props it is rendered with through to the banner', function () {
+    $rendered = renderRandomBanner(['ref' => 'posts', 'class' => 'my-6', 'thin' => true]);
+
+    expect($rendered)
+        ->toContain('?ref=posts')
+        ->toContain('my-6');
+});
+
+function renderRandomBanner(array $data = []): string
+{
+    return Blade::render('@include("components.banners.randomBanner")', $data);
+}


### PR DESCRIPTION
The banner in the docs sidebar was always picked at random, so setting an ad on a repository in `/admin` had no effect there. The `ad_id` on a repository only ever drove the GitHub README image.

`spatie/laravel-uptime-monitor` is set to the Flare ad, but its docs pages still rotated through Media Library, Ray, Mailcoach and the rest on every request.

Ads now have a `banner_component` field, so an ad points at the banner that represents it. A repository with an active ad shows that banner on its docs pages. The dropdown is filled from the files in `resources/views/components/banners`, so a new banner shows up as an option on its own.

`randomBanner.blade.php` used to name `laravel-medialibrary` and `laravel-event-sourcing` directly. Those two are now set up through their own ad, so the partial no longer knows about individual repositories and everything runs through the admin.

Heads up on one side effect: both repositories currently point at the Flare ad with randomization on, so this changes their GitHub README banner to their own product ad. That seemed like the more sensible ad for those repos anyway.

The migration also links up ads whose name already matches a banner, which covers `Flare`, `Mailcoach` and `Ray`. The rest stay empty and can be set in the admin.

Repositories without an ad, ads without a banner, and inactive ads all keep the random rotation.

Also drops a leftover `ray()` call in `DocsController`.
